### PR TITLE
Fix missing dependencies for Search class

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -15,11 +15,11 @@ use ONGR\ElasticsearchDSL\Aggregation\AbstractAggregation;
 use ONGR\ElasticsearchDSL\Highlight\Highlight;
 use ONGR\ElasticsearchDSL\SearchEndpoint\SearchEndpointFactory;
 use ONGR\ElasticsearchDSL\SearchEndpoint\SearchEndpointInterface;
+use ONGR\ElasticsearchDSL\Serializer\Normalizer\CustomReferencedNormalizer;
+use ONGR\ElasticsearchDSL\Serializer\OrderedSerializer;
 use ONGR\ElasticsearchDSL\Sort\AbstractSort;
 use ONGR\ElasticsearchDSL\Sort\Sorts;
 use ONGR\ElasticsearchDSL\Suggester\AbstractSuggester;
-use ONGR\ElasticsearchBundle\Serializer\Normalizer\CustomReferencedNormalizer;
-use ONGR\ElasticsearchBundle\Serializer\OrderedSerializer;
 use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
 
 /**

--- a/src/SearchEndpoint/AbstractSearchEndpoint.php
+++ b/src/SearchEndpoint/AbstractSearchEndpoint.php
@@ -11,7 +11,7 @@
 
 namespace ONGR\ElasticsearchDSL\SearchEndpoint;
 
-use ONGR\ElasticsearchBundle\Serializer\Normalizer\AbstractNormalizable;
+use ONGR\ElasticsearchDSL\Serializer\Normalizer\AbstractNormalizable;
 
 /**
  * Abstract class used to define search endpoint with references.

--- a/src/SearchEndpoint/QueryEndpoint.php
+++ b/src/SearchEndpoint/QueryEndpoint.php
@@ -15,7 +15,7 @@ use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 use ONGR\ElasticsearchDSL\Query\BoolQuery;
 use ONGR\ElasticsearchDSL\Query\FilteredQuery;
-use ONGR\ElasticsearchBundle\Serializer\Normalizer\OrderedNormalizerInterface;
+use ONGR\ElasticsearchDSL\Serializer\Normalizer\OrderedNormalizerInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 

--- a/src/Serializer/Normalizer/AbstractNormalizable.php
+++ b/src/Serializer/Normalizer/AbstractNormalizable.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Serializer\Normalizer;
+
+use ONGR\ElasticsearchDSL\ParametersTrait;
+use Symfony\Component\Serializer\Normalizer\NormalizableInterface;
+
+/**
+ * Custom abstract normalizer which can save references for other objects.
+ */
+abstract class AbstractNormalizable implements NormalizableInterface
+{
+    use ParametersTrait {
+        ParametersTrait::hasParameter as hasReference;
+        ParametersTrait::getParameter as getReference;
+        ParametersTrait::getParameters as getReferences;
+        ParametersTrait::addParameter as addReference;
+        ParametersTrait::setParameters as setReferences;
+    }
+}

--- a/src/Serializer/Normalizer/CustomReferencedNormalizer.php
+++ b/src/Serializer/Normalizer/CustomReferencedNormalizer.php
@@ -1,0 +1,45 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Serializer\Normalizer;
+
+use Symfony\Component\Serializer\Normalizer\CustomNormalizer;
+
+/**
+ * Normalizer used with referenced normalized objects.
+ */
+class CustomReferencedNormalizer extends CustomNormalizer
+{
+    /**
+     * @var array
+     */
+    private $references = [];
+
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($object, $format = null, array $context = [])
+    {
+        $object->setReferences($this->references);
+        $data = parent::normalize($object, $format, $context);
+        $this->references = array_merge($this->references, $object->getReferences());
+
+        return $data;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsNormalization($data, $format = null)
+    {
+        return $data instanceof AbstractNormalizable;
+    }
+}

--- a/src/Serializer/Normalizer/OrderedNormalizerInterface.php
+++ b/src/Serializer/Normalizer/OrderedNormalizerInterface.php
@@ -1,0 +1,25 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Serializer\Normalizer;
+
+/**
+ * This should be implemented by normalizable object that required to be processed in specific order.
+ */
+interface OrderedNormalizerInterface
+{
+    /**
+     * Returns normalization priority.
+     *
+     * @return int
+     */
+    public function getOrder();
+}

--- a/src/Serializer/OrderedSerializer.php
+++ b/src/Serializer/OrderedSerializer.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Serializer;
+
+use ONGR\ElasticsearchDSL\Serializer\Normalizer\OrderedNormalizerInterface;
+use Symfony\Component\Serializer\Serializer;
+
+/**
+ * Custom serializer which orders data before normalization.
+ */
+class OrderedSerializer extends Serializer
+{
+    /**
+     * {@inheritdoc}
+     */
+    public function normalize($data, $format = null, array $context = [])
+    {
+        return parent::normalize(
+            is_array($data) ? $this->order($data) : $data,
+            $format,
+            $context
+        );
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function denormalize($data, $type, $format = null, array $context = [])
+    {
+        return parent::denormalize(
+            is_array($data) ? $this->order($data) : $data,
+            $type,
+            $format,
+            $context
+        );
+    }
+
+    /**
+     * Orders objects if can be done.
+     *
+     * @param array $data Data to order.
+     *
+     * @return array
+     */
+    private function order(array $data)
+    {
+        $filteredData = $this->filterOrderable($data);
+
+        if (!empty($filteredData)) {
+            uasort(
+                $filteredData,
+                function (OrderedNormalizerInterface $a, OrderedNormalizerInterface $b) {
+                    return $a->getOrder() > $b->getOrder();
+                }
+            );
+
+            return array_merge($filteredData, array_diff_key($data, $filteredData));
+        }
+
+        return $data;
+    }
+
+    /**
+     * Filters out data which can be ordered.
+     *
+     * @param array $array Data to filter out.
+     *
+     * @return array
+     */
+    private function filterOrderable($array)
+    {
+        return array_filter(
+            $array,
+            function ($value) {
+                return $value instanceof OrderedNormalizerInterface;
+            }
+        );
+    }
+}

--- a/tests/SearchTest.php
+++ b/tests/SearchTest.php
@@ -1,0 +1,28 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL;
+
+use ONGR\ElasticsearchDSL\Search;
+
+/**
+ * Test for Search.
+ */
+class SearchTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests Search constructor.
+     */
+    public function testItCanBeInstantiated()
+    {
+        $this->assertInstanceOf('ONGR\ElasticsearchDSL\Search', new Search());
+    }
+}


### PR DESCRIPTION
Some dependencies were missing for `ONGR\ElasticsearchDSL\Search`. I backported those from `ONGR\ElasticsearchBundle`.