### PR TITLE
Make modifier argument optional.

### DIFF
--- a/src/Query/FunctionScoreQuery.php
+++ b/src/Query/FunctionScoreQuery.php
@@ -81,7 +81,7 @@ class FunctionScoreQuery implements BuilderInterface
      *
      * @return $this
      */
-    public function addFieldValueFactorFunction($field, $factor, $modifier, BuilderInterface $filter = null)
+    public function addFieldValueFactorFunction($field, $factor, $modifier = 'none', BuilderInterface $filter = null)
     {
         $function = [
             'field_value_factor' => [


### PR DESCRIPTION
In method addFieldValueFactorFunction.
Elasticsearch documentation says that it is optional.