### PR TITLE
Use empty stdClass instead of empty array.

### DIFF
--- a/src/Query/FunctionScoreQuery.php
+++ b/src/Query/FunctionScoreQuery.php
@@ -162,7 +162,7 @@ class FunctionScoreQuery implements BuilderInterface
     public function addRandomFunction($seed = null, BuilderInterface $filter = null)
     {
         $function = [
-            'random_score' => $seed ? [ 'seed' => $seed ] : [],
+            'random_score' => $seed ? [ 'seed' => $seed ] : new \stdClass(),
         ];
 
         $this->applyFilter($function, $filter);


### PR DESCRIPTION
In method addRandomFunction.
Elasticsearch expects object not array and empty array will not be made into object.