### PR TITLE
fixed bug for addPostFilter when using wrong Interface

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -204,7 +204,7 @@ class Search
     {
         $this
             ->getEndpoint(PostFilterEndpoint::NAME)
-            ->add($filter, $boolType, $key);
+            ->addToBool($filter, $boolType, $key);
 
         return $this;
     }


### PR DESCRIPTION
https://github.com/ongr-io/ElasticsearchDSL/blob/master/docs/Filter/Post.md with Bool example giving wrong results because at `Search->addPostFilter->add`  was giving parameters  (`$filter, $boolType, $key`), and the `add` method accepting only 2 parameters (`BuilderInterface $builder, $key = null`).