### PR TITLE
Function script score options are now being merged

### DIFF
--- a/src/Query/FunctionScoreQuery.php
+++ b/src/Query/FunctionScoreQuery.php
@@ -189,11 +189,13 @@ class FunctionScoreQuery implements BuilderInterface
         BuilderInterface $filter = null
     ) {
         $function = [
-            'script_score' => [
-                'script' => $script,
-                'params' => $params,
+            'script_score' => array_merge(
+                [
+                    'script' => $script,
+                    'params' => $params,
+                ],
                 $options
-            ],
+            ),
         ];
 
         $this->applyFilter($function, $filter);


### PR DESCRIPTION
before we had
``` json
{
"script": "...",
"params": {},
"0"
}
```