### PR TITLE
Adapt to support ESB v1.0.*

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,22 +1,12 @@
 sudo: false
-
 language: php
-
 php:
-  - 5.4
   - 5.5
   - 5.6
   - 7.0
   - hhvm
-
-matrix:
-  allow_failures:
-    - php: hhvm
-    - php: 7.0
-
 before_script:
   - composer install --no-interaction
-
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.clover
-  - vendor/bin/phpcs -p --standard=vendor/ongr/ongr-strict-standard/Ongr --ignore=vendor/ ./
+  - vendor/bin/phpcs -p --standard=PSR2 --ignore=vendor/,Tests/app/ ./

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,9 +4,11 @@ php:
   - 5.5
   - 5.6
   - 7.0
-  - hhvm
+matrix:
+  allow_failures:
+    - php: hhvm
 before_script:
   - composer install --no-interaction
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.clover
-  - vendor/bin/phpcs -p --standard=PSR2 --ignore=vendor/,Tests/app/ ./
+  - vendor/bin/phpcs -p --standard=PSR2 --ignore=vendor/ ./

--- a/composer.json
+++ b/composer.json
@@ -17,8 +17,7 @@
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4",
-        "squizlabs/php_codesniffer": "~2.0",
-        "ongr/ongr-strict-standard": "~2.0"
+        "squizlabs/php_codesniffer": "~2.0"
     },
     "autoload": {
         "psr-4": {

--- a/docs/Aggregation/TopHits.md
+++ b/docs/Aggregation/TopHits.md
@@ -43,7 +43,7 @@ so that the top matching documents can be aggregated per bucket.
 And now the query via DSL:
 
 ```php
-$sort = new Sort('last_activity_date', Sort::ORDER_DESC);
+$sort = new FieldSort('last_activity_date', Sort::DESC);
 $sorts = new Sorts();
 $sorts->addSort($sort);
 $topHitsAggregation = new TopHitsAggregation('top_tag_hits', 1, null, $sorts);

--- a/docs/Aggregation/TopHits.md
+++ b/docs/Aggregation/TopHits.md
@@ -43,7 +43,7 @@ so that the top matching documents can be aggregated per bucket.
 And now the query via DSL:
 
 ```php
-$sort = new FieldSort('last_activity_date', Sort::DESC);
+$sort = new FieldSort('last_activity_date', FieldSort::DESC);
 $sorts = new Sorts();
 $sorts->addSort($sort);
 $topHitsAggregation = new TopHitsAggregation('top_tag_hits', 1, null, $sorts);

--- a/src/SearchEndpoint/SortEndpoint.php
+++ b/src/SearchEndpoint/SortEndpoint.php
@@ -11,9 +11,6 @@
 
 namespace ONGR\ElasticsearchDSL\SearchEndpoint;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
-use ONGR\ElasticsearchDSL\Sort\AbstractSort;
-use ONGR\ElasticsearchDSL\Sort\FieldSort;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**

--- a/src/SearchEndpoint/SortEndpoint.php
+++ b/src/SearchEndpoint/SortEndpoint.php
@@ -13,7 +13,7 @@ namespace ONGR\ElasticsearchDSL\SearchEndpoint;
 
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\Sort\AbstractSort;
-use ONGR\ElasticsearchDSL\Sort\Sorts;
+use ONGR\ElasticsearchDSL\Sort\FieldSort;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
 /**


### PR DESCRIPTION
- Using `FieldSort`, instead of `Sort` object
- Replace `ONGR Strick Standard` by `PSR2`