### PR TITLE
Fixed | Nested query with bool doesn't work when there is only one MU…

### DIFF
--- a/src/Query/BoolQuery.php
+++ b/src/Query/BoolQuery.php
@@ -112,7 +112,7 @@ class BoolQuery implements BuilderInterface
             $query = array_shift($mustContainer);
 
             if ($query->getType() == 'match') {
-                $output = [self::MUST => [$query->getType() => $query->toArray()]];
+                $output = [self::MUST => [[$query->getType() => $query->toArray()]]];
             } else {
                 $output = [$query->getType() => $query->toArray()];
             }
@@ -123,11 +123,7 @@ class BoolQuery implements BuilderInterface
         foreach ($this->container as $boolType => $builders) {
             /** @var BuilderInterface $builder */
             foreach ($builders as $builder) {
-                if (count($this->container[$boolType]) == 1) {
-                    $output[$boolType] = [$builder->getType() => $builder->toArray()];
-                } else {
-                    $output[$boolType][] = [$builder->getType() => $builder->toArray()];
-                }
+                $output[$boolType][] = [$builder->getType() => $builder->toArray()];
             }
         }
 

--- a/src/Query/BoolQuery.php
+++ b/src/Query/BoolQuery.php
@@ -123,7 +123,11 @@ class BoolQuery implements BuilderInterface
         foreach ($this->container as $boolType => $builders) {
             /** @var BuilderInterface $builder */
             foreach ($builders as $builder) {
-                $output[$boolType][] = [$builder->getType() => $builder->toArray()];
+                if (count($this->container[$boolType]) == 1) {
+                    $output[$boolType] = [$builder->getType() => $builder->toArray()];
+                } else {
+                    $output[$boolType][] = [$builder->getType() => $builder->toArray()];
+                }
             }
         }
 

--- a/src/Query/BoolQuery.php
+++ b/src/Query/BoolQuery.php
@@ -111,7 +111,13 @@ class BoolQuery implements BuilderInterface
             $mustContainer = $this->container[self::MUST];
             $query = array_shift($mustContainer);
 
-            return [$query->getType() => $query->toArray()];
+            if ($query->getType() == 'match') {
+                $output = [self::MUST => [$query->getType() => $query->toArray()]];
+            } else {
+                $output = [$query->getType() => $query->toArray()];
+            }
+
+            return $output;
         }
 
         foreach ($this->container as $boolType => $builders) {

--- a/tests/Query/NestedQueryTest.php
+++ b/tests/Query/NestedQueryTest.php
@@ -11,27 +11,32 @@
 
 namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
 
+use ONGR\ElasticsearchDSL\Query\BoolQuery;
+use ONGR\ElasticsearchDSL\Query\MatchQuery;
 use ONGR\ElasticsearchDSL\Query\NestedQuery;
+use ONGR\ElasticsearchDSL\Query\RangeQuery;
+use ONGR\ElasticsearchDSL\Search;
 
 class NestedQueryTest extends \PHPUnit_Framework_TestCase
 {
+
     /**
      * Tests toArray method.
      */
     public function testToArray()
     {
         $missingFilterMock = $this->getMockBuilder('ONGR\ElasticsearchDSL\Filter\MissingFilter')
-            ->setConstructorArgs(['test_field'])
-            ->getMock();
+                                  ->setConstructorArgs(['test_field'])
+                                  ->getMock();
         $missingFilterMock->expects($this->any())
-            ->method('getType')
-            ->willReturn('test_type');
+                          ->method('getType')
+                          ->willReturn('test_type');
         $missingFilterMock->expects($this->any())
-            ->method('toArray')
-            ->willReturn(['testKey' => 'testValue']);
+                          ->method('toArray')
+                          ->willReturn(['testKey' => 'testValue']);
 
         $result = [
-            'path' => 'test_path',
+            'path'  => 'test_path',
             'query' => [
                 'test_type' => ['testKey' => 'testValue'],
             ],
@@ -47,14 +52,91 @@ class NestedQueryTest extends \PHPUnit_Framework_TestCase
     public function testParameters()
     {
         $nestedQuery = $this->getMockBuilder('ONGR\ElasticsearchDSL\Query\NestedQuery')
-            ->disableOriginalConstructor()
-            ->setMethods(null)
-            ->getMock();
+                            ->disableOriginalConstructor()
+                            ->setMethods(null)
+                            ->getMock();
 
         $this->assertTrue(method_exists($nestedQuery, 'addParameter'), 'Nested query must have addParameter method');
         $this->assertTrue(method_exists($nestedQuery, 'setParameters'), 'Nested query must have setParameters method');
         $this->assertTrue(method_exists($nestedQuery, 'getParameters'), 'Nested query must have getParameters method');
         $this->assertTrue(method_exists($nestedQuery, 'hasParameter'), 'Nested query must have hasParameter method');
         $this->assertTrue(method_exists($nestedQuery, 'getParameter'), 'Nested query must have getParameter method');
+    }
+
+    /**
+     * Tests if Nested Query has 1 Boolean query.
+     */
+    public function testWith1Boolean()
+    {
+
+        // Case 1: With one Bool Query
+        $matchQuery = new MatchQuery('some.field', 'someValue');
+
+        $boolQuery = new BoolQuery();
+        $boolQuery->add($matchQuery, BoolQuery::MUST);
+
+        $nestedQuery = new NestedQuery('urls', $boolQuery);
+
+        $search = new Search();
+        $search->addQuery($nestedQuery);
+
+        $expected = [
+            'query' => [
+                'nested' => [
+                    'path'  => 'urls',
+                    'query' => [
+                        'bool' => [
+                            'must' => [
+                                'match' => ['some.field' => ['query' => 'someValue']]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $this->assertEquals($expected, $search->toArray());
+    }
+
+    /**
+     * Tests if Nested Query has 2 Boolean queries.
+     */
+    public function testWith2Boolean()
+    {
+        $matchQuery = new MatchQuery('obj1.name', 'blue');
+        $rangeQuery = new RangeQuery('obj1.count', ['gt' => 5]);
+
+        $boolQuery = new BoolQuery();
+        $boolQuery->add($matchQuery);
+        $boolQuery->add($rangeQuery);
+
+        $nestedQuery = new NestedQuery('obj1', $boolQuery);
+        $nestedQuery->addParameter('score_mode', 'avg');
+
+        $search = new Search();
+        $search->addQuery($nestedQuery);
+
+        $expected = [
+            'query' => [
+                'nested' => [
+                    'path'       => 'obj1',
+                    'score_mode' => 'avg',
+                    'query'      => [
+                        'bool' => [
+                            'must' => [
+                                [
+                                    'match' => ['obj1.name' => ['query' => 'blue']]
+                                ],
+                                [
+                                    'range' => ['obj1.count' => ['gt' => 5]]
+                                ]
+                            ]
+                        ]
+                    ]
+                ]
+            ]
+        ];
+
+        $this->assertEquals($expected, $search->toArray());
     }
 }

--- a/tests/Query/NestedQueryTest.php
+++ b/tests/Query/NestedQueryTest.php
@@ -88,7 +88,9 @@ class NestedQueryTest extends \PHPUnit_Framework_TestCase
                     'query' => [
                         'bool' => [
                             'must' => [
-                                'match' => ['some.field' => ['query' => 'someValue']]
+                                [
+                                    'match' => ['some.field' => ['query' => 'someValue']]
+                                ]
                             ]
                         ]
                     ]
@@ -123,7 +125,9 @@ class NestedQueryTest extends \PHPUnit_Framework_TestCase
                     'query' => [
                         'bool' => [
                             'should' => [
-                                'match' => ['some.field' => ['query' => 'someValue']]
+                                [
+                                    'match' => ['some.field' => ['query' => 'someValue']]
+                                ]
                             ]
                         ]
                     ]
@@ -245,9 +249,9 @@ class NestedQueryTest extends \PHPUnit_Framework_TestCase
                     'score_mode' => 'avg',
                     'query'      => [
                         'bool' => [
-                            'must' => ['match' => ['obj1.name' => ['query' => 'blue']]],
-                            'must_not' => ['term' => ['obj1.nickname' => 'color']],
-                            'should' => ['range' => ['obj1.count' => ['gt' => 5]]]
+                            'must' => [['match' => ['obj1.name' => ['query' => 'blue']]]],
+                            'must_not' => [['term' => ['obj1.nickname' => 'color']]],
+                            'should' => [['range' => ['obj1.count' => ['gt' => 5]]]]
                         ]
                     ]
                 ]


### PR DESCRIPTION
Related to this bug https://github.com/ongr-io/ElasticsearchDSL/issues/32