### PR TITLE
Add filter clause for BoolQuery

### DIFF
--- a/src/Query/BoolQuery.php
+++ b/src/Query/BoolQuery.php
@@ -17,7 +17,7 @@ use ONGR\ElasticsearchDSL\ParametersTrait;
 /**
  * Represents Elasticsearch "bool" query.
  *
- * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-query.html
  */
 class BoolQuery implements BuilderInterface
 {
@@ -26,6 +26,7 @@ class BoolQuery implements BuilderInterface
     const MUST = 'must';
     const MUST_NOT = 'must_not';
     const SHOULD = 'should';
+    const FILTER = 'filter';
 
     /**
      * @var array
@@ -41,6 +42,7 @@ class BoolQuery implements BuilderInterface
             self::MUST => [],
             self::MUST_NOT => [],
             self::SHOULD => [],
+            self::FILTER => [],
         ];
     }
 
@@ -52,8 +54,8 @@ class BoolQuery implements BuilderInterface
     public function isRelevant()
     {
         return
-            (count($this->container[self::MUST_NOT]) + count($this->container[self::SHOULD])) > 0
-            || count($this->container[self::MUST]) > 1;
+            count($this->container[self::MUST]) > 1 || count($this->container[self::MUST_NOT]) ||
+            count($this->container[self::SHOULD]) || count($this->container[self::FILTER]);
     }
 
     /**
@@ -66,7 +68,8 @@ class BoolQuery implements BuilderInterface
             return array_merge(
                 $this->container[self::MUST],
                 $this->container[self::MUST_NOT],
-                $this->container[self::SHOULD]
+                $this->container[self::SHOULD],
+                $this->container[self::FILTER]
             );
         }
 
@@ -86,7 +89,7 @@ class BoolQuery implements BuilderInterface
      */
     public function add(BuilderInterface $query, $type = self::MUST, $key = null)
     {
-        if (!in_array($type, (new \ReflectionObject($this))->getConstants())) {
+        if (!in_array($type, [self::MUST, self::MUST_NOT, self::SHOULD, self::FILTER])) {
             throw new \UnexpectedValueException(sprintf('The bool operator %s is not supported', $type));
         }
 

--- a/tests/Query/BoolQueryTest.php
+++ b/tests/Query/BoolQueryTest.php
@@ -113,4 +113,31 @@ class BoolQueryTest extends \PHPUnit_Framework_TestCase
         $result = $bool->getType();
         $this->assertEquals('bool', $result);
     }
+
+    /**
+     * Tests bool query in filter context.
+     */
+    public function testBoolInFilterContext()
+    {
+        $bool = new BoolQuery();
+        $bool->add(new TermQuery('key1', 'value1'), BoolQuery::FILTER);
+        $bool->add(new TermQuery('key2', 'value2'), BoolQuery::MUST);
+        $expected = [
+            'filter' => [
+                [
+                    'term' => [
+                        'key1' => 'value1',
+                    ],
+                ],
+            ],
+            'must' => [
+                [
+                    'term' => [
+                        'key2' => 'value2',
+                    ],
+                ],
+            ],
+        ];
+        $this->assertEquals($expected, $bool->toArray());
+    }
 }


### PR DESCRIPTION
This PR adds `filter` type support for `bool` query (Elasticsearch 2.0 feature).

This will allow us to deprecate all filters and implement full "query in filter context" support.