### PR TITLE
Deprecate filters

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_script:
   - composer install --no-interaction --prefer-dist
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.clover
-  - vendor/bin/phpcs -p --standard=PSR2 --ignore=vendor/ ./
+  - vendor/bin/phpcs -p --standard=PSR2 --ignore=vendor/,src/Filter/ ./
 after_script:
   - vendor/bin/coveralls
 notifications:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,16 @@
+CHANGELOG
+=========
+
+v1.x (201x)
+---
+
+- Fixed nested query in case `bool` with single `must` clause given (#32)
+- Deprecated all filters and filtered query (#50)
+- Added `filter` clause support for `BoolQuery` (#48)
+
+v1.0.1 (2015-12-16)
+---
+               
+- Fixed `function_score` query options handling (#35)
+- Added Symfony 3 compatibility
+- Added support for `timeout` and `terminate_after` options in Search endpoint (#34)

--- a/docs/Filter/Or.md
+++ b/docs/Filter/Or.md
@@ -1,5 +1,7 @@
 # Or Filter
 
+__DEPRECATED:__ `OrFilter` is deprecated and will be removed in 2.0. Use `BoolQuery` instead.
+
 > More info about or filter is in the [official elasticsearch docs][1]
 
 A filter that matches documents using the OR boolean operator on other filters.

--- a/src/Filter/AndFilter.php
+++ b/src/Filter/AndFilter.php
@@ -11,6 +11,11 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
+@trigger_error(
+    'The AndFilter class is deprecated and will be removed in 2.0. Use BoolQuery instead.',
+    E_USER_DEPRECATED
+);
+
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
@@ -18,6 +23,8 @@ use ONGR\ElasticsearchDSL\ParametersTrait;
  * Represents Elasticsearch "and" filter.
  *
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-and-filter.html
+ *
+ * @deprecated Will be removed in 2.0. Use the BoolQuery instead.
  */
 class AndFilter implements BuilderInterface
 {

--- a/src/Filter/BoolFilter.php
+++ b/src/Filter/BoolFilter.php
@@ -11,12 +11,19 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
+@trigger_error(
+    'The BoolFilter class is deprecated and will be removed in 2.0. Use BoolQuery instead.',
+    E_USER_DEPRECATED
+);
+
 use ONGR\ElasticsearchDSL\Query\BoolQuery;
 
 /**
  * Represents Elasticsearch "bool" filter.
  *
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-bool-filter.html
+ *
+ * @deprecated Will be removed in 2.0. Use the BoolQuery instead.
  */
 class BoolFilter extends BoolQuery
 {

--- a/src/Filter/ExistsFilter.php
+++ b/src/Filter/ExistsFilter.php
@@ -11,43 +11,20 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
+@trigger_error(
+    'The ExistsFilter class is deprecated and will be removed in 2.0. Use ExistsQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\ExistsQuery;
 
 /**
  * Represents Elasticsearch "exists" filter.
  *
  * @link http://www.elasticsearch.org/guide/en/elasticsearch/reference/current/query-dsl-exists-filter.html
+ *
+ * @deprecated Will be removed in 2.0. Use the ExistsQuery instead.
  */
-class ExistsFilter implements BuilderInterface
+class ExistsFilter extends ExistsQuery
 {
-    /**
-     * @var string
-     */
-    private $field;
-
-    /**
-     * @param string $field Field value.
-     */
-    public function __construct($field)
-    {
-        $this->field = $field;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return 'exists';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function toArray()
-    {
-        return [
-            'field' => $this->field,
-        ];
-    }
 }

--- a/src/Filter/GeoBoundingBoxFilter.php
+++ b/src/Filter/GeoBoundingBoxFilter.php
@@ -11,73 +11,18 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
-use ONGR\ElasticsearchDSL\ParametersTrait;
+@trigger_error(
+    'The GeoBoundingBoxFilter class is deprecated and will be removed in 2.0. Use GeoBoundingBoxQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\GeoBoundingBoxQuery;
 
 /**
  * Represents Elasticsearch "Geo Bounding Box" filter.
+ *
+ * @deprecated Will be removed in 2.0. Use the GeoBoundingBoxQuery instead.
  */
-class GeoBoundingBoxFilter implements BuilderInterface
+class GeoBoundingBoxFilter extends GeoBoundingBoxQuery
 {
-    use ParametersTrait;
-
-    /**
-     * @var array
-     */
-    private $values;
-
-    /**
-     * @var string
-     */
-    private $field;
-
-    /**
-     * @param string $field
-     * @param array  $values
-     * @param array  $parameters
-     */
-    public function __construct($field, $values, array $parameters = [])
-    {
-        $this->field = $field;
-        $this->values = $values;
-        $this->setParameters($parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return 'geo_bounding_box';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function toArray()
-    {
-        if (count($this->values) === 2) {
-            $query = [
-                $this->field => [
-                    'top_left' => $this->values[0],
-                    'bottom_right' => $this->values[1],
-                ],
-            ];
-        } elseif (count($this->values) === 4) {
-            $query = [
-                $this->field => [
-                    'top' => $this->values[0],
-                    'left' => $this->values[1],
-                    'bottom' => $this->values[2],
-                    'right' => $this->values[3],
-                ],
-            ];
-        } else {
-            throw new \LogicException('Geo Bounding Box filter must have 2 or 4 geo points set.');
-        }
-
-        $output = $this->processArray($query);
-
-        return $output;
-    }
 }

--- a/src/Filter/GeoDistanceFilter.php
+++ b/src/Filter/GeoDistanceFilter.php
@@ -11,65 +11,18 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
-use ONGR\ElasticsearchDSL\ParametersTrait;
+@trigger_error(
+    'The GeoDistanceFilter class is deprecated and will be removed in 2.0. Use GeoDistanceQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\GeoDistanceQuery;
 
 /**
  * Represents Elasticsearch "Geo Distance Filter" filter.
+ *
+ * @deprecated Will be removed in 2.0. Use the GeoDistanceQuery instead.
  */
-class GeoDistanceFilter implements BuilderInterface
+class GeoDistanceFilter extends GeoDistanceQuery
 {
-    use ParametersTrait;
-
-    /**
-     * @var string
-     */
-    private $field;
-
-    /**
-     * @var string
-     */
-    private $distance;
-
-    /**
-     * @var mixed
-     */
-    private $location;
-
-    /**
-     * @param string $field
-     * @param string $distance
-     * @param mixed  $location
-     * @param array  $parameters
-     */
-    public function __construct($field, $distance, $location, array $parameters = [])
-    {
-        $this->field = $field;
-        $this->distance = $distance;
-        $this->location = $location;
-
-        $this->setParameters($parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return 'geo_distance';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function toArray()
-    {
-        $query = [
-            'distance' => $this->distance,
-            $this->field => $this->location,
-        ];
-        $output = $this->processArray($query);
-
-        return $output;
-    }
 }

--- a/src/Filter/GeoDistanceRangeFilter.php
+++ b/src/Filter/GeoDistanceRangeFilter.php
@@ -11,62 +11,18 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
-use ONGR\ElasticsearchDSL\ParametersTrait;
+@trigger_error(
+    'The GeoDistanceRangeFilter class is deprecated and will be removed in 2.0. Use GeoDistanceRangeQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\GeoDistanceRangeQuery;
 
 /**
  * Represents Elasticsearch "Geo Distance Range Filter" filter.
+ *
+ * @deprecated Will be removed in 2.0. Use the GeoDistanceRangeQuery instead.
  */
-class GeoDistanceRangeFilter implements BuilderInterface
+class GeoDistanceRangeFilter extends GeoDistanceRangeQuery
 {
-    use ParametersTrait;
-
-    /**
-     * @var string
-     */
-    private $field;
-
-    /**
-     * @var array
-     */
-    private $range;
-
-    /**
-     * @var mixed
-     */
-    private $location;
-
-    /**
-     * @param string $field
-     * @param array  $range
-     * @param mixed  $location
-     * @param array  $parameters
-     */
-    public function __construct($field, $range, $location, array $parameters = [])
-    {
-        $this->field = $field;
-        $this->range = $range;
-        $this->location = $location;
-
-        $this->setParameters($parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return 'geo_distance_range';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function toArray()
-    {
-        $query = $this->range + [$this->field => $this->location];
-        $output = $this->processArray($query);
-
-        return $output;
-    }
 }

--- a/src/Filter/GeoPolygonFilter.php
+++ b/src/Filter/GeoPolygonFilter.php
@@ -11,55 +11,18 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
-use ONGR\ElasticsearchDSL\ParametersTrait;
+@trigger_error(
+    'The GeoPolygonFilter class is deprecated and will be removed in 2.0. Use GeoPolygonQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\GeoPolygonQuery;
 
 /**
  * Elasticsearch geo polygon filter.
+ *
+ * @deprecated Will be removed in 2.0. Use the GeoPolygonQuery instead.
  */
-class GeoPolygonFilter implements BuilderInterface
+class GeoPolygonFilter extends GeoPolygonQuery
 {
-    use ParametersTrait;
-
-    /**
-     * @var string
-     */
-    private $field;
-
-    /**
-     * @var array
-     */
-    private $points;
-
-    /**
-     * @param string $field
-     * @param array  $points
-     * @param array  $parameters
-     */
-    public function __construct($field, array $points = [], array $parameters = [])
-    {
-        $this->field = $field;
-        $this->points = $points;
-        $this->setParameters($parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return 'geo_polygon';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function toArray()
-    {
-        $query = [];
-        $query[$this->field] = ['points' => $this->points];
-        $output = $this->processArray($query);
-
-        return $output;
-    }
 }

--- a/src/Filter/GeoShapeFilter.php
+++ b/src/Filter/GeoShapeFilter.php
@@ -11,90 +11,18 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
-use ONGR\ElasticsearchDSL\ParametersTrait;
+@trigger_error(
+    'The GeoShapeFilter class is deprecated and will be removed in 2.0. Use GeoShapeQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\GeoShapeQuery;
 
 /**
  * Elasticsearch geo-shape filter.
+ *
+ * @deprecated Will be removed in 2.0. Use the GeoShapeQuery instead.
  */
-class GeoShapeFilter implements BuilderInterface
+class GeoShapeFilter extends GeoShapeQuery
 {
-    use ParametersTrait;
-
-    /**
-     * @var array
-     */
-    private $fields = [];
-
-    /**
-     * @param array $parameters
-     */
-    public function __construct(array $parameters = [])
-    {
-        $this->setParameters($parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return 'geo_shape';
-    }
-
-    /**
-     * Add geo-shape provided filter.
-     *
-     * @param string $field       Field name.
-     * @param string $type        Shape type.
-     * @param array  $coordinates Shape coordinates.
-     * @param array  $parameters  Additional parameters.
-     */
-    public function addShape($field, $type, array $coordinates, array $parameters = [])
-    {
-        $filter = array_merge(
-            $parameters,
-            [
-                'type' => $type,
-                'coordinates' => $coordinates,
-            ]
-        );
-
-        $this->fields[$field]['shape'] = $filter;
-    }
-
-    /**
-     * Add geo-shape pre-indexed filter.
-     *
-     * @param string $field      Field name.
-     * @param string $id         The ID of the document that containing the pre-indexed shape.
-     * @param string $type       Name of the index where the pre-indexed shape is.
-     * @param string $index      Index type where the pre-indexed shape is.
-     * @param string $path       The field specified as path containing the pre-indexed shape.
-     * @param array  $parameters Additional parameters.
-     */
-    public function addPreIndexedShape($field, $id, $type, $index, $path, array $parameters = [])
-    {
-        $filter = array_merge(
-            $parameters,
-            [
-                'id' => $id,
-                'type' => $type,
-                'index' => $index,
-                'path' => $path,
-            ]
-        );
-
-        $this->fields[$field]['indexed_shape'] = $filter;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function toArray()
-    {
-        $output = $this->processArray($this->fields);
-
-        return $output;
-    }
 }

--- a/src/Filter/GeohashCellFilter.php
+++ b/src/Filter/GeohashCellFilter.php
@@ -11,56 +11,18 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
-use ONGR\ElasticsearchDSL\ParametersTrait;
+@trigger_error(
+    'The GeohashCellFilter class is deprecated and will be removed in 2.0. Use GeohashCellQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\GeohashCellQuery;
 
 /**
  * Represents Elasticsearch "Geohash Cell" filter.
+ *
+ * @deprecated Will be removed in 2.0. Use the GeohashCellQuery instead.
  */
-class GeohashCellFilter implements BuilderInterface
+class GeohashCellFilter extends GeohashCellQuery
 {
-    use ParametersTrait;
-
-    /**
-     * @var string
-     */
-    private $field;
-
-    /**
-     * @var mixed
-     */
-    private $location;
-
-    /**
-     * @param string $field
-     * @param mixed  $location
-     * @param array  $parameters
-     */
-    public function __construct($field, $location, array $parameters = [])
-    {
-        $this->field = $field;
-        $this->location = $location;
-
-        $this->setParameters($parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return 'geohash_cell';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function toArray()
-    {
-        $query = [];
-        $query[$this->field] = $this->location;
-        $output = $this->processArray($query);
-
-        return $output;
-    }
 }

--- a/src/Filter/HasChildFilter.php
+++ b/src/Filter/HasChildFilter.php
@@ -11,49 +11,32 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
+@trigger_error(
+    'The HasChildFilter class is deprecated and will be removed in 2.0. Use HasChildQuery instead.',
+    E_USER_DEPRECATED
+);
+
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\DslTypeAwareTrait;
-use ONGR\ElasticsearchDSL\ParametersTrait;
+use ONGR\ElasticsearchDSL\Query\HasChildQuery;
 
 /**
  * Elasticsearch has_child filter.
+ *
+ * @deprecated Will be removed in 2.0. Use the BoolQuery instead.
  */
-class HasChildFilter implements BuilderInterface
+class HasChildFilter extends HasChildQuery
 {
-    use ParametersTrait;
     use DslTypeAwareTrait;
-
-    /**
-     * @var string
-     */
-    private $type;
-
-    /**
-     * @var BuilderInterface
-     */
-    private $query;
-
-    /**
-     * @param string           $type
-     * @param BuilderInterface $query
-     * @param array            $parameters
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function __construct($type, BuilderInterface $query, array $parameters = [])
-    {
-        $this->type = $type;
-        $this->query = $query;
-        $this->setParameters($parameters);
-        $this->setDslType('filter');
-    }
 
     /**
      * {@inheritdoc}
      */
-    public function getType()
+    public function __construct($type, BuilderInterface $query, array $parameters = [])
     {
-        return 'has_child';
+        $this->setDslType('filter');
+
+        parent::__construct($type, $query, $parameters);
     }
 
     /**
@@ -61,13 +44,13 @@ class HasChildFilter implements BuilderInterface
      */
     public function toArray()
     {
-        $query = [
-            'type' => $this->type,
-            $this->getDslType() => [$this->query->getType() => $this->query->toArray()],
-        ];
+        $result = parent::toArray();
 
-        $output = $this->processArray($query);
+        if ($this->getDslType() !== 'query') {
+            $result[$this->getDslType()] = $result['query'];
+            unset($result['query']);
+        }
 
-        return $output;
+        return $result;
     }
 }

--- a/src/Filter/HasParentFilter.php
+++ b/src/Filter/HasParentFilter.php
@@ -11,49 +11,32 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
+@trigger_error(
+    'The HasParentFilter class is deprecated and will be removed in 2.0. Use HasParentQuery instead.',
+    E_USER_DEPRECATED
+);
+
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\DslTypeAwareTrait;
-use ONGR\ElasticsearchDSL\ParametersTrait;
+use ONGR\ElasticsearchDSL\Query\HasParentQuery;
 
 /**
  * Elasticsearch has_parent filter.
+ *
+ * @deprecated Will be removed in 2.0. Use the HasParentQuery instead.
  */
-class HasParentFilter implements BuilderInterface
+class HasParentFilter extends HasParentQuery
 {
-    use ParametersTrait;
     use DslTypeAwareTrait;
-
-    /**
-     * @var string
-     */
-    private $parentType;
-
-    /**
-     * @var BuilderInterface
-     */
-    private $query;
-
-    /**
-     * @param string           $parentType
-     * @param BuilderInterface $query
-     * @param array            $parameters
-     *
-     * @throws \InvalidArgumentException
-     */
-    public function __construct($parentType, BuilderInterface $query, array $parameters = [])
-    {
-        $this->parentType = $parentType;
-        $this->query = $query;
-        $this->setParameters($parameters);
-        $this->setDslType('filter');
-    }
 
     /**
      * {@inheritdoc}
      */
-    public function getType()
+    public function __construct($type, BuilderInterface $query, array $parameters = [])
     {
-        return 'has_parent';
+        $this->setDslType('filter');
+
+        parent::__construct($type, $query, $parameters);
     }
 
     /**
@@ -61,13 +44,13 @@ class HasParentFilter implements BuilderInterface
      */
     public function toArray()
     {
-        $query = [
-            'parent_type' => $this->parentType,
-            $this->getDslType() => [$this->query->getType() => $this->query->toArray()],
-        ];
+        $result = parent::toArray();
 
-        $output = $this->processArray($query);
+        if ($this->getDslType() !== 'query') {
+            $result[$this->getDslType()] = $result['query'];
+            unset($result['query']);
+        }
 
-        return $output;
+        return $result;
     }
 }

--- a/src/Filter/IdsFilter.php
+++ b/src/Filter/IdsFilter.php
@@ -11,49 +11,18 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
-use ONGR\ElasticsearchDSL\ParametersTrait;
+@trigger_error(
+    'The IdsFilter class is deprecated and will be removed in 2.0. Use IdsQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\IdsQuery;
 
 /**
  * Represents Elasticsearch "ids" filter.
+ *
+ * @deprecated Will be removed in 2.0. Use the IdsQuery instead.
  */
-class IdsFilter implements BuilderInterface
+class IdsFilter extends IdsQuery
 {
-    use ParametersTrait;
-
-    /**
-     * @var string[]
-     */
-    private $values;
-
-    /**
-     * @param string[] $values     Ids' values.
-     * @param array    $parameters Optional parameters.
-     */
-    public function __construct($values, array $parameters = [])
-    {
-        $this->values = $values;
-        $this->setParameters($parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return 'ids';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function toArray()
-    {
-        $query = [];
-        $query['values'] = $this->values;
-
-        $output = $this->processArray($query);
-
-        return $output;
-    }
 }

--- a/src/Filter/IndicesFilter.php
+++ b/src/Filter/IndicesFilter.php
@@ -11,10 +11,17 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
+@trigger_error(
+    'The IndicesFilter class is deprecated and will be removed in 2.0. Use IndicesQuery instead.',
+    E_USER_DEPRECATED
+);
+
 use ONGR\ElasticsearchDSL\BuilderInterface;
 
 /**
  * Represents Elasticsearch "indices" filter.
+ *
+ * @deprecated Will be removed in 2.0. Use the IndicesQuery instead.
  */
 class IndicesFilter implements BuilderInterface
 {

--- a/src/Filter/LimitFilter.php
+++ b/src/Filter/LimitFilter.php
@@ -11,43 +11,20 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
+@trigger_error(
+    'The LimitFilter class is deprecated and will be removed in 2.0. Use LimitQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\LimitQuery;
 
 /**
  * Represents Elasticsearch "limit" filter.
  *
  * A limit filter limits the number of documents (per shard) to execute on.
+ *
+ * @deprecated Will be removed in 2.0. Use the LimitQuery instead.
  */
-class LimitFilter implements BuilderInterface
+class LimitFilter extends LimitQuery
 {
-    /**
-     * @var int
-     */
-    private $value;
-
-    /**
-     * @param int $value Number of documents (per shard) to execute on.
-     */
-    public function __construct($value)
-    {
-        $this->value = $value;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return 'limit';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function toArray()
-    {
-        return [
-            'value' => $this->value,
-        ];
-    }
 }

--- a/src/Filter/MatchAllFilter.php
+++ b/src/Filter/MatchAllFilter.php
@@ -11,28 +11,20 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
+@trigger_error(
+    'The MatchAllFilter class is deprecated and will be removed in 2.0. Use MatchAllQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\MatchAllQuery;
 
 /**
  * Represents Elasticsearch "match_all" filter.
  *
  * A filter matches on all documents.
+ *
+ * @deprecated Will be removed in 2.0. Use the MatchAllQuery instead.
  */
-class MatchAllFilter implements BuilderInterface
+class MatchAllFilter extends MatchAllQuery
 {
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return 'match_all';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function toArray()
-    {
-        return [];
-    }
 }

--- a/src/Filter/MissingFilter.php
+++ b/src/Filter/MissingFilter.php
@@ -11,49 +11,18 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
-use ONGR\ElasticsearchDSL\ParametersTrait;
+@trigger_error(
+    'The MissingFilter class is deprecated and will be removed in 2.0. Use MissingQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\MissingQuery;
 
 /**
  * Represents Elasticsearch "missing" filter.
+ *
+ * @deprecated Will be removed in 2.0. Use the MissingQuery instead.
  */
-class MissingFilter implements BuilderInterface
+class MissingFilter extends MissingQuery
 {
-    use ParametersTrait;
-
-    /**
-     * @var string
-     */
-    private $field;
-
-    /**
-     * @param string $field      Field name.
-     * @param array  $parameters Optional parameters.
-     */
-    public function __construct($field, array $parameters = [])
-    {
-        $this->field = $field;
-        $this->setParameters($parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return 'missing';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function toArray()
-    {
-        $query = [];
-        $query['field'] = $this->field;
-
-        $output = $this->processArray($query);
-
-        return $output;
-    }
 }

--- a/src/Filter/NestedFilter.php
+++ b/src/Filter/NestedFilter.php
@@ -11,60 +11,29 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
-use ONGR\ElasticsearchDSL\ParametersTrait;
+@trigger_error(
+    'The NestedFilter class is deprecated and will be removed in 2.0. Use NestedQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\NestedQuery;
 
 /**
  * Nested filter implementation.
+ *
+ * @deprecated Will be removed in 2.0. Use the NestedQuery instead.
  */
-class NestedFilter implements BuilderInterface
+class NestedFilter extends NestedQuery
 {
-    use ParametersTrait;
-
-    /**
-     * @var string
-     */
-    private $path;
-
-    /**
-     * @var BuilderInterface
-     */
-    private $query;
-
-    /**
-     * @param string           $path
-     * @param BuilderInterface $query
-     * @param array            $parameters
-     */
-    public function __construct($path, BuilderInterface $query, array $parameters = [])
-    {
-        $this->path = $path;
-        $this->query = $query;
-        $this->parameters = $parameters;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return 'nested';
-    }
-
     /**
      * {@inheritdoc}
      */
     public function toArray()
     {
-        $query = [
-            'path' => $this->path,
-            'filter' => [
-                $this->query->getType() => $this->query->toArray(),
-            ],
-        ];
+        $result = parent::toArray();
+        $result['filter'] = $result['query'];
+        unset($result['query']);
 
-        $output = $this->processArray($query);
-
-        return $output;
+        return $result;
     }
 }

--- a/src/Filter/NotFilter.php
+++ b/src/Filter/NotFilter.php
@@ -11,6 +11,11 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
+@trigger_error(
+    'The NotFilter class is deprecated and will be removed in 2.0. Use BoolQuery instead.',
+    E_USER_DEPRECATED
+);
+
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
@@ -18,6 +23,8 @@ use ONGR\ElasticsearchDSL\ParametersTrait;
  * Represents Elasticsearch "not" filter.
  *
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-not-filter.html
+ *
+ * @deprecated Will be removed in 2.0. Use the BoolQuery instead.
  */
 class NotFilter implements BuilderInterface
 {

--- a/src/Filter/OrFilter.php
+++ b/src/Filter/OrFilter.php
@@ -11,10 +11,17 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
+@trigger_error(
+    'The OrFilter class is deprecated and will be removed in 2.0. Use BoolQuery instead.',
+    E_USER_DEPRECATED
+);
+
 /**
  * Represents Elasticsearch "or" filter.
  *
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-or-filter.html
+ *
+ * @deprecated Will be removed in 2.0. Use the BoolQuery instead.
  */
 class OrFilter extends AndFilter
 {

--- a/src/Filter/PrefixFilter.php
+++ b/src/Filter/PrefixFilter.php
@@ -11,48 +11,22 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
-use ONGR\ElasticsearchDSL\ParametersTrait;
+@trigger_error(
+    'The PrefixFilter class is deprecated and will be removed in 2.0. Use PrefixQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\PrefixQuery;
 
 /**
  * Represents Elasticsearch "prefix" filter.
  *
  * Filters documents that have fields containing terms with a specified prefix.
+ *
+ * @deprecated Will be removed in 2.0. Use the PrefixQuery instead.
  */
-class PrefixFilter implements BuilderInterface
+class PrefixFilter extends PrefixQuery
 {
-    use ParametersTrait;
-
-    /**
-     * @var string
-     */
-    protected $field;
-
-    /**
-     * @var string
-     */
-    protected $value;
-
-    /**
-     * @param string $field      Field name.
-     * @param string $value      Value.
-     * @param array  $parameters Optional parameters.
-     */
-    public function __construct($field, $value, array $parameters = [])
-    {
-        $this->field = $field;
-        $this->value = $value;
-        $this->setParameters($parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return 'prefix';
-    }
-
     /**
      * {@inheritdoc}
      */

--- a/src/Filter/QueryFilter.php
+++ b/src/Filter/QueryFilter.php
@@ -11,11 +11,18 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
+@trigger_error(
+    'The QueryFilter class is deprecated and will be removed in 2.0.',
+    E_USER_DEPRECATED
+);
+
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
  * Represents Elasticsearch "query" filter.
+ *
+ * @deprecated Will be removed in 2.0. The query filter has been removed as queries and filters have been merged.
  */
 class QueryFilter implements BuilderInterface
 {

--- a/src/Filter/RangeFilter.php
+++ b/src/Filter/RangeFilter.php
@@ -11,28 +11,22 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
-use ONGR\ElasticsearchDSL\ParametersTrait;
+@trigger_error(
+    'The RangeFilter class is deprecated and will be removed in 2.0. Use RangeQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\RangeQuery;
 
 /**
  * Represents Elasticsearch "range" filter.
  *
  * Filters documents with fields that have terms within a certain range.
+ *
+ * @deprecated Will be removed in 2.0. Use the RangeQuery instead.
  */
-class RangeFilter implements BuilderInterface
+class RangeFilter extends RangeQuery
 {
-    use ParametersTrait;
-
-    /**
-     * @var string
-     */
-    private $field;
-
-    /**
-     * @var array
-     */
-    private $range;
-
     /**
      * @param string $field      Field name.
      * @param array  $range      Range values.
@@ -40,28 +34,6 @@ class RangeFilter implements BuilderInterface
      */
     public function __construct($field, $range, array $parameters = [])
     {
-        $this->field = $field;
-        $this->range = $range;
-        $this->setParameters($parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return 'range';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function toArray()
-    {
-        $query = [$this->field => $this->range];
-
-        $output = $this->processArray($query);
-
-        return $output;
+        parent::__construct($field, array_merge($range, $parameters));
     }
 }

--- a/src/Filter/RegexpFilter.php
+++ b/src/Filter/RegexpFilter.php
@@ -11,11 +11,18 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
+@trigger_error(
+    'The RegexpFilter class is deprecated and will be removed in 2.0. Use RegexpQuery instead.',
+    E_USER_DEPRECATED
+);
+
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
  * Represents Elasticsearch "regexp" filter.
+ *
+ * @deprecated Will be removed in 2.0. Use the RegexpQuery instead.
  */
 class RegexpFilter implements BuilderInterface
 {

--- a/src/Filter/ScriptFilter.php
+++ b/src/Filter/ScriptFilter.php
@@ -11,6 +11,11 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
+@trigger_error(
+    'The ScriptFilter class is deprecated and will be removed in 2.0. Use ScriptQuery instead.',
+    E_USER_DEPRECATED
+);
+
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
@@ -18,6 +23,8 @@ use ONGR\ElasticsearchDSL\ParametersTrait;
  * Represents Elasticsearch "script" filter.
  *
  * Allows to define scripts as filters.
+ *
+ * @deprecated Will be removed in 2.0. Use the ScriptQuery instead.
  */
 class ScriptFilter implements BuilderInterface
 {

--- a/src/Filter/TermFilter.php
+++ b/src/Filter/TermFilter.php
@@ -11,16 +11,20 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
-use ONGR\ElasticsearchDSL\ParametersTrait;
+@trigger_error(
+    'The TermFilter class is deprecated and will be removed in 2.0. Use TermQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\TermQuery;
 
 /**
  * Represents Elasticsearch "term" filter.
+ *
+ * @deprecated Will be removed in 2.0. Use the TermQuery instead.
  */
-class TermFilter implements BuilderInterface
+class TermFilter extends TermQuery
 {
-    use ParametersTrait;
-
     /**
      * @var string
      */
@@ -29,26 +33,17 @@ class TermFilter implements BuilderInterface
     /**
      * @var string
      */
-    private $term;
-
-    /**
-     * @param string $field      Field name.
-     * @param string $term       Field value.
-     * @param array  $parameters Optional parameters.
-     */
-    public function __construct($field, $term, array $parameters = [])
-    {
-        $this->field = $field;
-        $this->term = $term;
-        $this->setParameters($parameters);
-    }
+    private $value;
 
     /**
      * {@inheritdoc}
      */
-    public function getType()
+    public function __construct($field, $value, array $parameters = [])
     {
-        return 'term';
+        $this->field = $field;
+        $this->value = $value;
+
+        parent::__construct($field, $value, $parameters);
     }
 
     /**
@@ -56,7 +51,7 @@ class TermFilter implements BuilderInterface
      */
     public function toArray()
     {
-        $query = [$this->field => $this->term];
+        $query = [$this->field => $this->value];
 
         $output = $this->processArray($query);
 

--- a/src/Filter/TermsFilter.php
+++ b/src/Filter/TermsFilter.php
@@ -11,55 +11,18 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
-use ONGR\ElasticsearchDSL\ParametersTrait;
+@trigger_error(
+    'The TermsFilter class is deprecated and will be removed in 2.0. Use TermsQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\TermsQuery;
 
 /**
  * Represents Elasticsearch "terms" filter.
+ *
+ * @deprecated Will be removed in 2.0. Use the TermsQuery instead.
  */
-class TermsFilter implements BuilderInterface
+class TermsFilter extends TermsQuery
 {
-    use ParametersTrait;
-
-    /**
-     * @var string
-     */
-    private $field;
-
-    /**
-     * @var array
-     */
-    private $terms;
-
-    /**
-     * @param string $field      Field name.
-     * @param array  $terms      An array of terms.
-     * @param array  $parameters Optional parameters.
-     */
-    public function __construct($field, $terms, array $parameters = [])
-    {
-        $this->field = $field;
-        $this->terms = $terms;
-        $this->setParameters($parameters);
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return 'terms';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function toArray()
-    {
-        $query = [$this->field => $this->terms];
-
-        $output = $this->processArray($query);
-
-        return $output;
-    }
 }

--- a/src/Filter/TypeFilter.php
+++ b/src/Filter/TypeFilter.php
@@ -11,45 +11,20 @@
 
 namespace ONGR\ElasticsearchDSL\Filter;
 
-use ONGR\ElasticsearchDSL\BuilderInterface;
+@trigger_error(
+    'The TypeFilter class is deprecated and will be removed in 2.0. Use TypeQuery instead.',
+    E_USER_DEPRECATED
+);
+
+use ONGR\ElasticsearchDSL\Query\TypeQuery;
 
 /**
  * Represents Elasticsearch "type" filter.
  *
  * Filters documents matching the provided type.
+ *
+ * @deprecated Will be removed in 2.0. Use the TypeQuery instead.
  */
-class TypeFilter implements BuilderInterface
+class TypeFilter extends TypeQuery
 {
-    /**
-     * @var string
-     */
-    private $type;
-
-    /**
-     * Constructor.
-     *
-     * @param string $type Type name.
-     */
-    public function __construct($type)
-    {
-        $this->type = $type;
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getType()
-    {
-        return 'type';
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function toArray()
-    {
-        return [
-            'value' => $this->type,
-        ];
-    }
 }

--- a/src/Query/ExistsQuery.php
+++ b/src/Query/ExistsQuery.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Query;
+
+use ONGR\ElasticsearchDSL\BuilderInterface;
+
+/**
+ * Represents Elasticsearch "exists" query.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-exists-query.html
+ */
+class ExistsQuery implements BuilderInterface
+{
+    /**
+     * @var string
+     */
+    private $field;
+
+    /**
+     * Constructor.
+     *
+     * @param string $field Field value
+     */
+    public function __construct($field)
+    {
+        $this->field = $field;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'exists';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toArray()
+    {
+        return [
+            'field' => $this->field,
+        ];
+    }
+}

--- a/src/Query/FilteredQuery.php
+++ b/src/Query/FilteredQuery.php
@@ -11,12 +11,6 @@
 
 namespace ONGR\ElasticsearchDSL\Query;
 
-@trigger_error(
-    'The FilteredQuery class is deprecated and will be removed in 2.0. ' .
-    'Use the "bool" query instead with a "filter" clause.',
-    E_USER_DEPRECATED
-);
-
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
@@ -47,6 +41,12 @@ class FilteredQuery implements BuilderInterface
      */
     public function __construct($query = null, $filter = null)
     {
+        @trigger_error(
+            'The FilteredQuery class is deprecated and will be removed in 2.0. ' .
+            'Use the "bool" query instead with a "filter" clause.',
+            E_USER_DEPRECATED
+        );
+
         if ($query !== null) {
             $this->setQuery($query);
         }

--- a/src/Query/FilteredQuery.php
+++ b/src/Query/FilteredQuery.php
@@ -11,6 +11,12 @@
 
 namespace ONGR\ElasticsearchDSL\Query;
 
+@trigger_error(
+    'The FilteredQuery class is deprecated and will be removed in 2.0. ' .
+    'Use the "bool" query instead with a "filter" clause.',
+    E_USER_DEPRECATED
+);
+
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
@@ -18,6 +24,8 @@ use ONGR\ElasticsearchDSL\ParametersTrait;
  * Represents Elasticsearch "bool" filter.
  *
  * @link http://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-filtered-query.html
+ *
+ * @deprecated Will be removed in 2.0. Use the `bool` query instead with a `filter` clause.
  */
 class FilteredQuery implements BuilderInterface
 {

--- a/src/Query/GeoBoundingBoxQuery.php
+++ b/src/Query/GeoBoundingBoxQuery.php
@@ -1,0 +1,85 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Query;
+
+use ONGR\ElasticsearchDSL\BuilderInterface;
+use ONGR\ElasticsearchDSL\ParametersTrait;
+
+/**
+ * Represents Elasticsearch "geo_bounding_box" query.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-bounding-box-query.html
+ */
+class GeoBoundingBoxQuery implements BuilderInterface
+{
+    use ParametersTrait;
+
+    /**
+     * @var array
+     */
+    private $values;
+
+    /**
+     * @var string
+     */
+    private $field;
+
+    /**
+     * @param string $field
+     * @param array  $values
+     * @param array  $parameters
+     */
+    public function __construct($field, $values, array $parameters = [])
+    {
+        $this->field = $field;
+        $this->values = $values;
+        $this->setParameters($parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'geo_bounding_box';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toArray()
+    {
+        if (count($this->values) === 2) {
+            $query = [
+                $this->field => [
+                    'top_left' => $this->values[0],
+                    'bottom_right' => $this->values[1],
+                ],
+            ];
+        } elseif (count($this->values) === 4) {
+            $query = [
+                $this->field => [
+                    'top' => $this->values[0],
+                    'left' => $this->values[1],
+                    'bottom' => $this->values[2],
+                    'right' => $this->values[3],
+                ],
+            ];
+        } else {
+            throw new \LogicException('Geo Bounding Box filter must have 2 or 4 geo points set.');
+        }
+
+        $output = $this->processArray($query);
+
+        return $output;
+    }
+}

--- a/src/Query/GeoDistanceQuery.php
+++ b/src/Query/GeoDistanceQuery.php
@@ -15,11 +15,11 @@ use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
- * Represents Elasticsearch "terms" query.
+ * Represents Elasticsearch "geo_distance" query.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-query.html
  */
-class TermsQuery implements BuilderInterface
+class GeoDistanceQuery implements BuilderInterface
 {
     use ParametersTrait;
 
@@ -29,21 +29,27 @@ class TermsQuery implements BuilderInterface
     private $field;
 
     /**
-     * @var array
+     * @var string
      */
-    private $terms;
+    private $distance;
 
     /**
-     * Constructor.
-     *
-     * @param string $field      Field name
-     * @param array  $terms      An array of terms
-     * @param array  $parameters Optional parameters
+     * @var mixed
      */
-    public function __construct($field, $terms, array $parameters = [])
+    private $location;
+
+    /**
+     * @param string $field
+     * @param string $distance
+     * @param mixed  $location
+     * @param array  $parameters
+     */
+    public function __construct($field, $distance, $location, array $parameters = [])
     {
         $this->field = $field;
-        $this->terms = $terms;
+        $this->distance = $distance;
+        $this->location = $location;
+
         $this->setParameters($parameters);
     }
 
@@ -52,7 +58,7 @@ class TermsQuery implements BuilderInterface
      */
     public function getType()
     {
-        return 'terms';
+        return 'geo_distance';
     }
 
     /**
@@ -61,9 +67,9 @@ class TermsQuery implements BuilderInterface
     public function toArray()
     {
         $query = [
-            $this->field => $this->terms,
+            'distance' => $this->distance,
+            $this->field => $this->location,
         ];
-
         $output = $this->processArray($query);
 
         return $output;

--- a/src/Query/GeoDistanceRangeQuery.php
+++ b/src/Query/GeoDistanceRangeQuery.php
@@ -15,11 +15,11 @@ use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
- * Represents Elasticsearch "terms" query.
+ * Represents Elasticsearch "geo_distance_range" query.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-distance-range-query.html
  */
-class TermsQuery implements BuilderInterface
+class GeoDistanceRangeQuery implements BuilderInterface
 {
     use ParametersTrait;
 
@@ -31,19 +31,25 @@ class TermsQuery implements BuilderInterface
     /**
      * @var array
      */
-    private $terms;
+    private $range;
 
     /**
-     * Constructor.
-     *
-     * @param string $field      Field name
-     * @param array  $terms      An array of terms
-     * @param array  $parameters Optional parameters
+     * @var mixed
      */
-    public function __construct($field, $terms, array $parameters = [])
+    private $location;
+
+    /**
+     * @param string $field
+     * @param array  $range
+     * @param mixed  $location
+     * @param array  $parameters
+     */
+    public function __construct($field, $range, $location, array $parameters = [])
     {
         $this->field = $field;
-        $this->terms = $terms;
+        $this->range = $range;
+        $this->location = $location;
+
         $this->setParameters($parameters);
     }
 
@@ -52,7 +58,7 @@ class TermsQuery implements BuilderInterface
      */
     public function getType()
     {
-        return 'terms';
+        return 'geo_distance_range';
     }
 
     /**
@@ -60,10 +66,7 @@ class TermsQuery implements BuilderInterface
      */
     public function toArray()
     {
-        $query = [
-            $this->field => $this->terms,
-        ];
-
+        $query = $this->range + [$this->field => $this->location];
         $output = $this->processArray($query);
 
         return $output;

--- a/src/Query/GeoPolygonQuery.php
+++ b/src/Query/GeoPolygonQuery.php
@@ -15,11 +15,11 @@ use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
- * Represents Elasticsearch "terms" query.
+ * Represents Elasticsearch "geo_polygon" query.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-polygon-query.html
  */
-class TermsQuery implements BuilderInterface
+class GeoPolygonQuery implements BuilderInterface
 {
     use ParametersTrait;
 
@@ -31,19 +31,17 @@ class TermsQuery implements BuilderInterface
     /**
      * @var array
      */
-    private $terms;
+    private $points;
 
     /**
-     * Constructor.
-     *
-     * @param string $field      Field name
-     * @param array  $terms      An array of terms
-     * @param array  $parameters Optional parameters
+     * @param string $field
+     * @param array  $points
+     * @param array  $parameters
      */
-    public function __construct($field, $terms, array $parameters = [])
+    public function __construct($field, array $points = [], array $parameters = [])
     {
         $this->field = $field;
-        $this->terms = $terms;
+        $this->points = $points;
         $this->setParameters($parameters);
     }
 
@@ -52,7 +50,7 @@ class TermsQuery implements BuilderInterface
      */
     public function getType()
     {
-        return 'terms';
+        return 'geo_polygon';
     }
 
     /**
@@ -60,10 +58,7 @@ class TermsQuery implements BuilderInterface
      */
     public function toArray()
     {
-        $query = [
-            $this->field => $this->terms,
-        ];
-
+        $query = [$this->field => ['points' => $this->points]];
         $output = $this->processArray($query);
 
         return $output;

--- a/src/Query/GeoShapeQuery.php
+++ b/src/Query/GeoShapeQuery.php
@@ -1,0 +1,102 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Query;
+
+use ONGR\ElasticsearchDSL\BuilderInterface;
+use ONGR\ElasticsearchDSL\ParametersTrait;
+
+/**
+ * Represents Elasticsearch "geo_shape" query.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geo-shape-query.html
+ */
+class GeoShapeQuery implements BuilderInterface
+{
+    use ParametersTrait;
+
+    /**
+     * @var array
+     */
+    private $fields = [];
+
+    /**
+     * @param array $parameters
+     */
+    public function __construct(array $parameters = [])
+    {
+        $this->setParameters($parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'geo_shape';
+    }
+
+    /**
+     * Add geo-shape provided filter.
+     *
+     * @param string $field       Field name.
+     * @param string $type        Shape type.
+     * @param array  $coordinates Shape coordinates.
+     * @param array  $parameters  Additional parameters.
+     */
+    public function addShape($field, $type, array $coordinates, array $parameters = [])
+    {
+        $filter = array_merge(
+            $parameters,
+            [
+                'type' => $type,
+                'coordinates' => $coordinates,
+            ]
+        );
+
+        $this->fields[$field]['shape'] = $filter;
+    }
+
+    /**
+     * Add geo-shape pre-indexed filter.
+     *
+     * @param string $field      Field name.
+     * @param string $id         The ID of the document that containing the pre-indexed shape.
+     * @param string $type       Name of the index where the pre-indexed shape is.
+     * @param string $index      Index type where the pre-indexed shape is.
+     * @param string $path       The field specified as path containing the pre-indexed shape.
+     * @param array  $parameters Additional parameters.
+     */
+    public function addPreIndexedShape($field, $id, $type, $index, $path, array $parameters = [])
+    {
+        $filter = array_merge(
+            $parameters,
+            [
+                'id' => $id,
+                'type' => $type,
+                'index' => $index,
+                'path' => $path,
+            ]
+        );
+
+        $this->fields[$field]['indexed_shape'] = $filter;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toArray()
+    {
+        $output = $this->processArray($this->fields);
+
+        return $output;
+    }
+}

--- a/src/Query/GeohashCellQuery.php
+++ b/src/Query/GeohashCellQuery.php
@@ -15,11 +15,11 @@ use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
- * Represents Elasticsearch "terms" query.
+ * Represents Elasticsearch "geohash_cell" query.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-geohash-cell-query.html
  */
-class TermsQuery implements BuilderInterface
+class GeohashCellQuery implements BuilderInterface
 {
     use ParametersTrait;
 
@@ -29,21 +29,20 @@ class TermsQuery implements BuilderInterface
     private $field;
 
     /**
-     * @var array
+     * @var mixed
      */
-    private $terms;
+    private $location;
 
     /**
-     * Constructor.
-     *
-     * @param string $field      Field name
-     * @param array  $terms      An array of terms
-     * @param array  $parameters Optional parameters
+     * @param string $field
+     * @param mixed  $location
+     * @param array  $parameters
      */
-    public function __construct($field, $terms, array $parameters = [])
+    public function __construct($field, $location, array $parameters = [])
     {
         $this->field = $field;
-        $this->terms = $terms;
+        $this->location = $location;
+
         $this->setParameters($parameters);
     }
 
@@ -52,7 +51,7 @@ class TermsQuery implements BuilderInterface
      */
     public function getType()
     {
-        return 'terms';
+        return 'geohash_cell';
     }
 
     /**
@@ -60,10 +59,7 @@ class TermsQuery implements BuilderInterface
      */
     public function toArray()
     {
-        $query = [
-            $this->field => $this->terms,
-        ];
-
+        $query = [$this->field => $this->location];
         $output = $this->processArray($query);
 
         return $output;

--- a/src/Query/HasChildQuery.php
+++ b/src/Query/HasChildQuery.php
@@ -15,7 +15,9 @@ use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
- * Elasticsearch has_child query class.
+ * Represents Elasticsearch "has_child" query.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-child-query.html
  */
 class HasChildQuery implements BuilderInterface
 {

--- a/src/Query/HasParentQuery.php
+++ b/src/Query/HasParentQuery.php
@@ -15,7 +15,9 @@ use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
- * Elasticsearch has_parent query class.
+ * Represents Elasticsearch "has_parent" query.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-has-parent-query.html
  */
 class HasParentQuery implements BuilderInterface
 {

--- a/src/Query/IdsQuery.php
+++ b/src/Query/IdsQuery.php
@@ -15,7 +15,9 @@ use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
- * Elasticsearch ids query class.
+ * Represents Elasticsearch "ids" query.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-ids-query.html
  */
 class IdsQuery implements BuilderInterface
 {

--- a/src/Query/IndicesQuery.php
+++ b/src/Query/IndicesQuery.php
@@ -14,7 +14,9 @@ namespace ONGR\ElasticsearchDSL\Query;
 use ONGR\ElasticsearchDSL\BuilderInterface;
 
 /**
- * Elasticsearch indices query class.
+ * Represents Elasticsearch "indices" query.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-indices-query.html
  */
 class IndicesQuery implements BuilderInterface
 {

--- a/src/Query/LimitQuery.php
+++ b/src/Query/LimitQuery.php
@@ -1,0 +1,53 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Query;
+
+use ONGR\ElasticsearchDSL\BuilderInterface;
+
+/**
+ * Represents Elasticsearch "limit" query.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-limit-query.html
+ */
+class LimitQuery implements BuilderInterface
+{
+    /**
+     * @var int
+     */
+    private $value;
+
+    /**
+     * @param int $value Number of documents (per shard) to execute on
+     */
+    public function __construct($value)
+    {
+        $this->value = $value;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'limit';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toArray()
+    {
+        return [
+            'value' => $this->value,
+        ];
+    }
+}

--- a/src/Query/MatchAllQuery.php
+++ b/src/Query/MatchAllQuery.php
@@ -15,7 +15,9 @@ use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
- * Elasticsearch match_all query class.
+ * Represents Elasticsearch "bool" query.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-match-all-query.html
  */
 class MatchAllQuery implements BuilderInterface
 {

--- a/src/Query/MissingQuery.php
+++ b/src/Query/MissingQuery.php
@@ -15,11 +15,11 @@ use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
- * Represents Elasticsearch "terms" query.
+ * Represents Elasticsearch "missing" query.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-missing-query.html
  */
-class TermsQuery implements BuilderInterface
+class MissingQuery implements BuilderInterface
 {
     use ParametersTrait;
 
@@ -29,21 +29,14 @@ class TermsQuery implements BuilderInterface
     private $field;
 
     /**
-     * @var array
-     */
-    private $terms;
-
-    /**
      * Constructor.
      *
      * @param string $field      Field name
-     * @param array  $terms      An array of terms
      * @param array  $parameters Optional parameters
      */
-    public function __construct($field, $terms, array $parameters = [])
+    public function __construct($field, array $parameters = [])
     {
         $this->field = $field;
-        $this->terms = $terms;
         $this->setParameters($parameters);
     }
 
@@ -52,7 +45,7 @@ class TermsQuery implements BuilderInterface
      */
     public function getType()
     {
-        return 'terms';
+        return 'missing';
     }
 
     /**
@@ -60,10 +53,7 @@ class TermsQuery implements BuilderInterface
      */
     public function toArray()
     {
-        $query = [
-            $this->field => $this->terms,
-        ];
-
+        $query = ['field' => $this->field];
         $output = $this->processArray($query);
 
         return $output;

--- a/src/Query/NestedQuery.php
+++ b/src/Query/NestedQuery.php
@@ -15,7 +15,9 @@ use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
- * Elasticsearch nested query class.
+ * Represents Elasticsearch "nested" query.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-nested-query.html
  */
 class NestedQuery implements BuilderInterface
 {
@@ -34,11 +36,13 @@ class NestedQuery implements BuilderInterface
     /**
      * @param string           $path
      * @param BuilderInterface $query
+     * @param array            $parameters
      */
-    public function __construct($path, BuilderInterface $query)
+    public function __construct($path, BuilderInterface $query, array $parameters = [])
     {
         $this->path = $path;
         $this->query = $query;
+        $this->parameters = $parameters;
     }
 
     /**

--- a/src/Query/PrefixQuery.php
+++ b/src/Query/PrefixQuery.php
@@ -11,13 +11,48 @@
 
 namespace ONGR\ElasticsearchDSL\Query;
 
-use ONGR\ElasticsearchDSL\Filter\PrefixFilter;
+use ONGR\ElasticsearchDSL\BuilderInterface;
+use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
  * Represents Elasticsearch "prefix" query.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-prefix-query.html
  */
-class PrefixQuery extends PrefixFilter
+class PrefixQuery implements BuilderInterface
 {
+    use ParametersTrait;
+
+    /**
+     * @var string
+     */
+    protected $field;
+
+    /**
+     * @var string
+     */
+    protected $value;
+
+    /**
+     * @param string $field      Field name.
+     * @param string $value      Value.
+     * @param array  $parameters Optional parameters.
+     */
+    public function __construct($field, $value, array $parameters = [])
+    {
+        $this->field = $field;
+        $this->value = $value;
+        $this->setParameters($parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'prefix';
+    }
+
     /**
      * {@inheritdoc}
      */

--- a/src/Query/RegexpQuery.php
+++ b/src/Query/RegexpQuery.php
@@ -15,7 +15,9 @@ use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
- * Regexp query class.
+ * Represents Elasticsearch "regexp" query.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-regexp-query.html
  */
 class RegexpQuery implements BuilderInterface
 {

--- a/src/Query/ScriptQuery.php
+++ b/src/Query/ScriptQuery.php
@@ -15,35 +15,26 @@ use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
- * Represents Elasticsearch "terms" query.
+ * Represents Elasticsearch "script" query.
  *
- * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-terms-query.html
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-script-query.html
  */
-class TermsQuery implements BuilderInterface
+class ScriptQuery implements BuilderInterface
 {
     use ParametersTrait;
 
     /**
      * @var string
      */
-    private $field;
+    private $script;
 
     /**
-     * @var array
-     */
-    private $terms;
-
-    /**
-     * Constructor.
-     *
-     * @param string $field      Field name
-     * @param array  $terms      An array of terms
+     * @param string $script     Script
      * @param array  $parameters Optional parameters
      */
-    public function __construct($field, $terms, array $parameters = [])
+    public function __construct($script, array $parameters = [])
     {
-        $this->field = $field;
-        $this->terms = $terms;
+        $this->script = $script;
         $this->setParameters($parameters);
     }
 
@@ -52,7 +43,7 @@ class TermsQuery implements BuilderInterface
      */
     public function getType()
     {
-        return 'terms';
+        return 'script';
     }
 
     /**
@@ -60,12 +51,9 @@ class TermsQuery implements BuilderInterface
      */
     public function toArray()
     {
-        $query = [
-            $this->field => $this->terms,
-        ];
-
+        $query = ['inline' => $this->script];
         $output = $this->processArray($query);
 
-        return $output;
+        return ['script' => $output];
     }
 }

--- a/src/Query/TermQuery.php
+++ b/src/Query/TermQuery.php
@@ -15,7 +15,9 @@ use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
- * Elasticsearch term query class.
+ * Represents Elasticsearch "term" query.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-term-query.html
  */
 class TermQuery implements BuilderInterface
 {

--- a/src/Query/TypeQuery.php
+++ b/src/Query/TypeQuery.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Query;
+
+use ONGR\ElasticsearchDSL\BuilderInterface;
+
+/**
+ * Represents Elasticsearch "type" query.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-query.html
+ */
+class TypeQuery implements BuilderInterface  // TODO: add test
+{
+    /**
+     * @var string
+     */
+    private $type;
+
+    /**
+     * Constructor.
+     *
+     * @param string $type Type name
+     */
+    public function __construct($type)
+    {
+        $this->type = $type;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'type';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toArray()
+    {
+        return [
+            'value' => $this->type,
+        ];
+    }
+}

--- a/tests/Aggregation/CardinalityAggregationTest.php
+++ b/tests/Aggregation/CardinalityAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\CardinalityAggregation;
 

--- a/tests/Aggregation/ChildrenAggregationTest.php
+++ b/tests/Aggregation/ChildrenAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\ChildrenAggregation;
 

--- a/tests/Aggregation/DateRangeAggregationTest.php
+++ b/tests/Aggregation/DateRangeAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\DateRangeAggregation;
 

--- a/tests/Aggregation/FilterAggregationTest.php
+++ b/tests/Aggregation/FilterAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\AbstractAggregation;
 use ONGR\ElasticsearchDSL\Aggregation\FilterAggregation;

--- a/tests/Aggregation/FiltersAggregationTest.php
+++ b/tests/Aggregation/FiltersAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\AbstractAggregation;
 use ONGR\ElasticsearchDSL\Aggregation\FiltersAggregation;

--- a/tests/Aggregation/GeoBoundsAggregationTest.php
+++ b/tests/Aggregation/GeoBoundsAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\AbstractAggregation;
 use ONGR\ElasticsearchDSL\Aggregation\GeoBoundsAggregation;

--- a/tests/Aggregation/GeoDistanceAggregationTest.php
+++ b/tests/Aggregation/GeoDistanceAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\GeoDistanceAggregation;
 

--- a/tests/Aggregation/GeoHashGridAggregationTest.php
+++ b/tests/Aggregation/GeoHashGridAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\GeoHashGridAggregation;
 

--- a/tests/Aggregation/GlobalAggregationTest.php
+++ b/tests/Aggregation/GlobalAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\GlobalAggregation;
 

--- a/tests/Aggregation/Ipv4RangeAggregationTest.php
+++ b/tests/Aggregation/Ipv4RangeAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\AbstractAggregation;
 use ONGR\ElasticsearchDSL\Aggregation\Ipv4RangeAggregation;

--- a/tests/Aggregation/MissingAggregationTest.php
+++ b/tests/Aggregation/MissingAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\MissingAggregation;
 

--- a/tests/Aggregation/NestedAggregationTest.php
+++ b/tests/Aggregation/NestedAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\AbstractAggregation;
 use ONGR\ElasticsearchDSL\Aggregation\NestedAggregation;

--- a/tests/Aggregation/PercentileRanksAggregationTest.php
+++ b/tests/Aggregation/PercentileRanksAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\AbstractAggregation;
 use ONGR\ElasticsearchDSL\Aggregation\PercentileRanksAggregation;

--- a/tests/Aggregation/PercentilesAggregationTest.php
+++ b/tests/Aggregation/PercentilesAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\PercentilesAggregation;
 

--- a/tests/Aggregation/RangeAggregationTest.php
+++ b/tests/Aggregation/RangeAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\AbstractAggregation;
 use ONGR\ElasticsearchDSL\Aggregation\RangeAggregation;

--- a/tests/Aggregation/ReverseNestedAggregationTest.php
+++ b/tests/Aggregation/ReverseNestedAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\AbstractAggregation;
 use ONGR\ElasticsearchDSL\Aggregation\ReverseNestedAggregation;

--- a/tests/Aggregation/StatsAggregationTest.php
+++ b/tests/Aggregation/StatsAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\AbstractAggregation;
 use ONGR\ElasticsearchDSL\Aggregation\StatsAggregation;

--- a/tests/Aggregation/TermsAggregationTest.php
+++ b/tests/Aggregation/TermsAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\AbstractAggregation;
 use ONGR\ElasticsearchDSL\Aggregation\TermsAggregation;

--- a/tests/Aggregation/TopHitsAggregationTest.php
+++ b/tests/Aggregation/TopHitsAggregationTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Aggregation\TopHitsAggregation;
 use ONGR\ElasticsearchDSL\Sort\FieldSort;

--- a/tests/Filter/AndFilterTest.php
+++ b/tests/Filter/AndFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\AndFilter;
 

--- a/tests/Filter/ExistsFilterTest.php
+++ b/tests/Filter/ExistsFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\ExistsFilter;
 

--- a/tests/Filter/GeoBoundingBoxFilterTest.php
+++ b/tests/Filter/GeoBoundingBoxFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\GeoBoundingBoxFilter;
 

--- a/tests/Filter/GeoDistanceFilterTest.php
+++ b/tests/Filter/GeoDistanceFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\GeoDistanceFilter;
 

--- a/tests/Filter/GeoDistanceRangeFilterTest.php
+++ b/tests/Filter/GeoDistanceRangeFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\GeoDistanceRangeFilter;
 

--- a/tests/Filter/GeoPolygonFilterTest.php
+++ b/tests/Filter/GeoPolygonFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\GeoPolygonFilter;
 

--- a/tests/Filter/HasChildFilterTest.php
+++ b/tests/Filter/HasChildFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\HasChildFilter;
 

--- a/tests/Filter/HasParentFilterTest.php
+++ b/tests/Filter/HasParentFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\HasParentFilter;
 

--- a/tests/Filter/IdsFilterTest.php
+++ b/tests/Filter/IdsFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\IdsFilter;
 

--- a/tests/Filter/IndicesFilterTest.php
+++ b/tests/Filter/IndicesFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\IndicesFilter;
 

--- a/tests/Filter/LimitFilterTest.php
+++ b/tests/Filter/LimitFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\LimitFilter;
 

--- a/tests/Filter/MatchAllFilterTest.php
+++ b/tests/Filter/MatchAllFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\MatchAllFilter;
 

--- a/tests/Filter/MissingFilterTest.php
+++ b/tests/Filter/MissingFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\MissingFilter;
 

--- a/tests/Filter/NestedFilterTest.php
+++ b/tests/Filter/NestedFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\NestedFilter;
 use ONGR\ElasticsearchDSL\Filter\TermFilter;

--- a/tests/Filter/NotFilterTest.php
+++ b/tests/Filter/NotFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\NotFilter;
 

--- a/tests/Filter/OrFilterTest.php
+++ b/tests/Filter/OrFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\OrFilter;
 

--- a/tests/Filter/PrefixFilterTest.php
+++ b/tests/Filter/PrefixFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\PrefixFilter;
 

--- a/tests/Filter/QueryFilterTest.php
+++ b/tests/Filter/QueryFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\QueryFilter;
 

--- a/tests/Filter/RangeFilterTest.php
+++ b/tests/Filter/RangeFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\RangeFilter;
 

--- a/tests/Filter/RangeFilterTest.php
+++ b/tests/Filter/RangeFilterTest.php
@@ -35,9 +35,14 @@ class RangeFilterTest extends \PHPUnit_Framework_TestCase
             // Case #1.
             ['', [], [], ['' => []]],
             // Case #2.
-            ['foo', [1, 5], [], ['foo' => [0 => 1, 1 => 5]]],
+            ['foo', ['gte' => 1, 'lte' => 5], [], ['foo' => ['gte' => 1, 'lte' => 5]]],
             // Case #3.
-            ['test', ['foo', 'bar'], ['type' => 'acme'], ['test' => [0 => 'foo', 1 => 'bar'], 'type' => 'acme']],
+            [
+                'test',
+                ['gte' => 1, 'lte' => 5],
+                ['type' => 'acme'],
+                ['test' => ['gte' => 1, 'lte' => 5, 'type' => 'acme']]
+            ],
         ];
     }
 

--- a/tests/Filter/RegexpFilterTest.php
+++ b/tests/Filter/RegexpFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\RegexpFilter;
 

--- a/tests/Filter/ScriptFilterTest.php
+++ b/tests/Filter/ScriptFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\ScriptFilter;
 

--- a/tests/Filter/TermFilterTest.php
+++ b/tests/Filter/TermFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\TermFilter;
 

--- a/tests/Filter/TermsFilterTest.php
+++ b/tests/Filter/TermsFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\TermsFilter;
 

--- a/tests/Filter/TypeFilterTest.php
+++ b/tests/Filter/TypeFilterTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Filter;
+namespace ONGR\ElasticsearchDSL\Tests\Filter;
 
 use ONGR\ElasticsearchDSL\Filter\TypeFilter;
 

--- a/tests/Highlight/HighlightTest.php
+++ b/tests/Highlight/HighlightTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Highlight;
+namespace ONGR\ElasticsearchDSL\Tests\Highlight;
 
 use ONGR\ElasticsearchDSL\Highlight\Highlight;
 

--- a/tests/Query/BoolQueryTest.php
+++ b/tests/Query/BoolQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Aggregation;
+namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
 use ONGR\ElasticsearchDSL\Query\BoolQuery;
 use ONGR\ElasticsearchDSL\Query\MatchAllQuery;

--- a/tests/Query/ExistsQueryTest.php
+++ b/tests/Query/ExistsQueryTest.php
@@ -1,0 +1,29 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Tests\Query;
+
+use ONGR\ElasticsearchDSL\Query\ExistsQuery;
+
+/**
+ * Unit test for ExistsQuery.
+ */
+class ExistsQueryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests ExistsQuery#toArray() method.
+     */
+    public function testToArray()
+    {
+        $query = new ExistsQuery('bar');
+        $this->assertEquals(['field' => 'bar'], $query->toArray());
+    }
+}

--- a/tests/Query/FunctionScoreQueryTest.php
+++ b/tests/Query/FunctionScoreQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+namespace ONGR\ElasticsearchDSL\Tests\Query;
 
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\Query\FunctionScoreQuery;

--- a/tests/Query/FuzzyLikeThisQueryTest.php
+++ b/tests/Query/FuzzyLikeThisQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+namespace ONGR\ElasticsearchDSL\Tests\Query;
 
 use ONGR\ElasticsearchDSL\Query\FuzzyLikeThisQuery;
 

--- a/tests/Query/GeoBoundingBoxQueryTest.php
+++ b/tests/Query/GeoBoundingBoxQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+namespace ONGR\ElasticsearchDSL\Tests\Query;
 
 use ONGR\ElasticsearchDSL\Filter\GeoBoundingBoxFilter;
 

--- a/tests/Query/GeoBoundingBoxQueryTest.php
+++ b/tests/Query/GeoBoundingBoxQueryTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+
+use ONGR\ElasticsearchDSL\Filter\GeoBoundingBoxFilter;
+
+class GeoBoundingBoxQueryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test if exception is thrown when geo points are not set.
+     *
+     * @expectedException \LogicException
+     */
+    public function testGeoBoundBoxFilterException()
+    {
+        $filter = new GeoBoundingBoxFilter('location', []);
+        $filter->toArray();
+    }
+
+    /**
+     * Data provider for testToArray().
+     *
+     * @return array
+     */
+    public function getArrayDataProvider()
+    {
+        return [
+            // Case #1 (2 values).
+            [
+                'location',
+                [
+                    ['lat' => 40.73, 'lon' => -74.1],
+                    ['lat' => 40.01, 'lon' => -71.12],
+                ],
+                ['parameter' => 'value'],
+                [
+                    'location' => [
+                        'top_left' => ['lat' => 40.73, 'lon' => -74.1],
+                        'bottom_right' => ['lat' => 40.01, 'lon' => -71.12],
+                    ],
+                    'parameter' => 'value',
+                ],
+            ],
+            // Case #2 (4 values).
+            [
+                'location',
+                [40.73, -74.1, 40.01, -71.12],
+                ['parameter' => 'value'],
+                [
+                    'location' => [
+                        'top' => 40.73,
+                        'left' => -74.1,
+                        'bottom' => 40.01,
+                        'right' => -71.12,
+                    ],
+                    'parameter' => 'value',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Tests toArray method.
+     *
+     * @param string $field      Field name.
+     * @param array  $values     Bounding box values.
+     * @param array  $parameters Optional parameters.
+     * @param array  $expected   Expected result.
+     *
+     * @dataProvider getArrayDataProvider
+     */
+    public function testToArray($field, $values, $parameters, $expected)
+    {
+        $filter = new GeoBoundingBoxFilter($field, $values, $parameters);
+        $result = $filter->toArray();
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/Query/GeoDistanceQueryTest.php
+++ b/tests/Query/GeoDistanceQueryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+
+use ONGR\ElasticsearchDSL\Query\GeoDistanceQuery;
+
+class GeoDistanceQueryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Data provider for testToArray().
+     *
+     * @return array
+     */
+    public function getArrayDataProvider()
+    {
+        return [
+            // Case #1.
+            [
+                'location',
+                '200km',
+                ['lat' => 40, 'lon' => -70],
+                [],
+                ['distance' => '200km', 'location' => ['lat' => 40, 'lon' => -70]],
+            ],
+            // Case #2.
+            [
+                'location',
+                '20km',
+                ['lat' => 0, 'lon' => 0],
+                ['parameter' => 'value'],
+                ['distance' => '20km', 'location' => ['lat' => 0, 'lon' => 0], 'parameter' => 'value'],
+            ],
+        ];
+    }
+
+    /**
+     * Tests toArray() method.
+     *
+     * @param string $field      Field name.
+     * @param string $distance   Distance.
+     * @param array  $location   Location.
+     * @param array  $parameters Optional parameters.
+     * @param array  $expected   Expected result.
+     *
+     * @dataProvider getArrayDataProvider
+     */
+    public function testToArray($field, $distance, $location, $parameters, $expected)
+    {
+        $query = new GeoDistanceQuery($field, $distance, $location, $parameters);
+        $result = $query->toArray();
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/Query/GeoDistanceQueryTest.php
+++ b/tests/Query/GeoDistanceQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+namespace ONGR\ElasticsearchDSL\Tests\Query;
 
 use ONGR\ElasticsearchDSL\Query\GeoDistanceQuery;
 

--- a/tests/Query/GeoDistanceRangeQueryTest.php
+++ b/tests/Query/GeoDistanceRangeQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+namespace ONGR\ElasticsearchDSL\Tests\Query;
 
 use ONGR\ElasticsearchDSL\Query\GeoDistanceRangeQuery;
 

--- a/tests/Query/GeoDistanceRangeQueryTest.php
+++ b/tests/Query/GeoDistanceRangeQueryTest.php
@@ -1,0 +1,62 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+
+use ONGR\ElasticsearchDSL\Query\GeoDistanceRangeQuery;
+
+class GeoDistanceRangeQueryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Data provider to testToArray.
+     *
+     * @return array
+     */
+    public function getArrayDataProvider()
+    {
+        return [
+            // Case #1.
+            [
+                'location',
+                ['from' => '200km', 'to' => '400km'],
+                ['lat' => 40, 'lon' => -70],
+                [],
+                ['from' => '200km', 'to' => '400km', 'location' => ['lat' => 40, 'lon' => -70]],
+            ],
+            // Case #2.
+            [
+                'location',
+                ['from' => '150km', 'to' => '180km'],
+                ['lat' => 0, 'lon' => 0],
+                ['parameter' => 'value'],
+                ['from' => '150km', 'to' => '180km', 'location' => ['lat' => 0, 'lon' => 0], 'parameter' => 'value'],
+            ],
+        ];
+    }
+
+    /**
+     * Tests toArray method.
+     *
+     * @param string $field      Field name.
+     * @param array  $range      Distance range.
+     * @param array  $location   Location.
+     * @param array  $parameters Optional parameters.
+     * @param array  $expected   Expected result.
+     *
+     * @dataProvider getArrayDataProvider
+     */
+    public function testToArray($field, $range, $location, $parameters, $expected)
+    {
+        $query = new GeoDistanceRangeQuery($field, $range, $location, $parameters);
+        $result = $query->toArray();
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/Query/GeoPolygonQueryTest.php
+++ b/tests/Query/GeoPolygonQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+namespace ONGR\ElasticsearchDSL\Tests\Query;
 
 use ONGR\ElasticsearchDSL\Query\GeoPolygonQuery;
 

--- a/tests/Query/GeoPolygonQueryTest.php
+++ b/tests/Query/GeoPolygonQueryTest.php
@@ -1,0 +1,88 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+
+use ONGR\ElasticsearchDSL\Query\GeoPolygonQuery;
+
+class GeoPolygonQueryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Data provider to testToArray.
+     *
+     * @return array
+     */
+    public function getArrayDataProvider()
+    {
+        return [
+            // Case #1.
+            [
+                'location',
+                [
+                    ['lat' => 20, 'lon' => -80],
+                    ['lat' => 30, 'lon' => -40],
+                    ['lat' => 70, 'lon' => -90],
+                ],
+                [],
+                [
+                    'location' => [
+                        'points' => [
+                            ['lat' => 20, 'lon' => -80],
+                            ['lat' => 30, 'lon' => -40],
+                            ['lat' => 70, 'lon' => -90],
+                        ],
+                    ],
+                ],
+            ],
+            // Case #2.
+            [
+                'location',
+                [],
+                ['parameter' => 'value'],
+                [
+                    'location' => ['points' => []],
+                    'parameter' => 'value',
+                ],
+            ],
+            // Case #3.
+            [
+                'location',
+                [
+                    ['lat' => 20, 'lon' => -80],
+                ],
+                ['parameter' => 'value'],
+                [
+                    'location' => [
+                        'points' => [['lat' => 20, 'lon' => -80]],
+                    ],
+                    'parameter' => 'value',
+                ],
+            ],
+        ];
+    }
+
+    /**
+     * Tests toArray method.
+     *
+     * @param string $field      Field name.
+     * @param array  $points     Polygon's points.
+     * @param array  $parameters Optional parameters.
+     * @param array  $expected   Expected result.
+     *
+     * @dataProvider getArrayDataProvider
+     */
+    public function testToArray($field, $points, $parameters, $expected)
+    {
+        $filter = new GeoPolygonQuery($field, $points, $parameters);
+        $result = $filter->toArray();
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/Query/GeoShapeQueryTest.php
+++ b/tests/Query/GeoShapeQueryTest.php
@@ -1,0 +1,61 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+
+use ONGR\ElasticsearchDSL\Query\GeoShapeQuery;
+
+class GeoShapeQueryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Tests toArray() method.
+     */
+    public function testToArray()
+    {
+        $filter = new GeoShapeQuery(['param1' => 'value1']);
+        $filter->addShape('location', 'envelope', [[13, 53], [14, 52]]);
+
+        $expected = [
+            'location' => [
+                'shape' => [
+                    'type' => 'envelope',
+                    'coordinates' => [[13, 53], [14, 52]],
+                ],
+            ],
+            'param1' => 'value1',
+        ];
+
+        $this->assertEquals($expected, $filter->toArray());
+    }
+
+    /**
+     * Test for toArray() in case of pre-indexed shape.
+     */
+    public function testToArrayIndexed()
+    {
+        $filter = new GeoShapeQuery(['param1' => 'value1']);
+        $filter->addPreIndexedShape('location', 'DEU', 'countries', 'shapes', 'location');
+
+        $expected = [
+            'location' => [
+                'indexed_shape' => [
+                    'id' => 'DEU',
+                    'type' => 'countries',
+                    'index' => 'shapes',
+                    'path' => 'location',
+                ],
+            ],
+            'param1' => 'value1',
+        ];
+
+        $this->assertEquals($expected, $filter->toArray());
+    }
+}

--- a/tests/Query/GeoShapeQueryTest.php
+++ b/tests/Query/GeoShapeQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+namespace ONGR\ElasticsearchDSL\Tests\Query;
 
 use ONGR\ElasticsearchDSL\Query\GeoShapeQuery;
 

--- a/tests/Query/GeohashCellQueryTest.php
+++ b/tests/Query/GeohashCellQueryTest.php
@@ -1,0 +1,59 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+
+use ONGR\ElasticsearchDSL\Query\GeohashCellQuery;
+
+class GeohashCellQueryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Data provider for testToArray().
+     *
+     * @return array
+     */
+    public function getArrayDataProvider()
+    {
+        return [
+            // Case #1.
+            [
+                'location',
+                ['lat' => 40, 'lon' => -70],
+                [],
+                ['location' => ['lat' => 40, 'lon' => -70]],
+            ],
+            // Case #2.
+            [
+                'location',
+                ['lat' => 0, 'lon' => 0],
+                ['parameter' => 'value'],
+                ['location' => ['lat' => 0, 'lon' => 0], 'parameter' => 'value'],
+            ],
+        ];
+    }
+
+    /**
+     * Tests toArray() method.
+     *
+     * @param string $field      Field name.
+     * @param array  $location   Location.
+     * @param array  $parameters Optional parameters.
+     * @param array  $expected   Expected result.
+     *
+     * @dataProvider getArrayDataProvider
+     */
+    public function testToArray($field, $location, $parameters, $expected)
+    {
+        $query = new GeohashCellQuery($field, $location, $parameters);
+        $result = $query->toArray();
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/Query/GeohashCellQueryTest.php
+++ b/tests/Query/GeohashCellQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+namespace ONGR\ElasticsearchDSL\Tests\Query;
 
 use ONGR\ElasticsearchDSL\Query\GeohashCellQuery;
 

--- a/tests/Query/HasChildQueryTest.php
+++ b/tests/Query/HasChildQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+namespace ONGR\ElasticsearchDSL\Tests\Query;
 
 use ONGR\ElasticsearchDSL\Query\HasChildQuery;
 

--- a/tests/Query/HasParentQueryTest.php
+++ b/tests/Query/HasParentQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+namespace ONGR\ElasticsearchDSL\Tests\Query;
 
 use ONGR\ElasticsearchDSL\Query\HasParentQuery;
 

--- a/tests/Query/LimitQueryTest.php
+++ b/tests/Query/LimitQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+namespace ONGR\ElasticsearchDSL\Tests\Query;
 
 use ONGR\ElasticsearchDSL\Query\LimitQuery;
 

--- a/tests/Query/LimitQueryTest.php
+++ b/tests/Query/LimitQueryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+
+use ONGR\ElasticsearchDSL\Query\LimitQuery;
+
+class LimitQueryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test for query toArray() method.
+     */
+    public function testToArray()
+    {
+        $query = new LimitQuery(3);
+        $expectedResult = ['value' => 3];
+        $this->assertEquals($expectedResult, $query->toArray());
+    }
+}

--- a/tests/Query/MissingQueryTest.php
+++ b/tests/Query/MissingQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+namespace ONGR\ElasticsearchDSL\Tests\Query;
 
 use ONGR\ElasticsearchDSL\Query\MissingQuery;
 

--- a/tests/Query/MissingQueryTest.php
+++ b/tests/Query/MissingQueryTest.php
@@ -1,0 +1,48 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+
+use ONGR\ElasticsearchDSL\Query\MissingQuery;
+
+class MissingQueryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Data provider to testGetToArray.
+     *
+     * @return array
+     */
+    public function getArrayDataProvider()
+    {
+        return [
+            // Case 1.
+            ['user', [], ['field' => 'user']],
+            // Case 2.
+            ['user', ['existence' => true], ['field' => 'user', 'existence' => true]],
+        ];
+    }
+
+    /**
+     * Test for query toArray() method.
+     *
+     * @param string $field
+     * @param array  $parameters
+     * @param array  $expected
+     *
+     * @dataProvider getArrayDataProvider
+     */
+    public function testToArray($field, $parameters, $expected)
+    {
+        $query = new MissingQuery($field, $parameters);
+        $result = $query->toArray();
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/Query/NestedQueryTest.php
+++ b/tests/Query/NestedQueryTest.php
@@ -13,51 +13,58 @@ namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
 
 use ONGR\ElasticsearchDSL\Query\BoolQuery;
 use ONGR\ElasticsearchDSL\Query\NestedQuery;
+use ONGR\ElasticsearchDSL\Query\TermsQuery;
 use ONGR\ElasticsearchDSL\Query\TermQuery;
 
 class NestedQueryTest extends \PHPUnit_Framework_TestCase
 {
     /**
-     * Tests toArray method.
+     * Data provider to testGetToArray.
+     *
+     * @return array
      */
-    public function testToArray()
+    public function getArrayDataProvider()
     {
-        $missingFilterMock = $this->getMockBuilder('ONGR\ElasticsearchDSL\Filter\MissingFilter')
-            ->setConstructorArgs(['test_field'])
-            ->getMock();
-        $missingFilterMock->expects($this->any())
-            ->method('getType')
-            ->willReturn('test_type');
-        $missingFilterMock->expects($this->any())
-            ->method('toArray')
-            ->willReturn(['testKey' => 'testValue']);
-
-        $result = [
-            'path' => 'test_path',
-            'query' => [
-                'test_type' => ['testKey' => 'testValue'],
+        $query = [
+            'terms' => [
+                'foo' => 'bar',
             ],
         ];
 
-        $query = new NestedQuery('test_path', $missingFilterMock);
-        $this->assertEquals($result, $query->toArray());
+        return [
+            'query_only' => [
+                'product.sub_item',
+                [],
+                ['path' => 'product.sub_item', 'query' => $query],
+            ],
+            'query_with_parameters' => [
+                'product.sub_item',
+                ['_cache' => true, '_name' => 'named_result'],
+                [
+                    'path' => 'product.sub_item',
+                    'query' => $query,
+                    '_cache' => true,
+                    '_name' => 'named_result',
+                ],
+            ],
+        ];
     }
 
     /**
-     * Tests if Nested Query has parameters.
+     * Test for query toArray() method.
+     *
+     * @param string $path
+     * @param array  $parameters
+     * @param array  $expected
+     *
+     * @dataProvider getArrayDataProvider
      */
-    public function testParameters()
+    public function testToArray($path, $parameters, $expected)
     {
-        $nestedQuery = $this->getMockBuilder('ONGR\ElasticsearchDSL\Query\NestedQuery')
-            ->disableOriginalConstructor()
-            ->setMethods(null)
-            ->getMock();
-
-        $this->assertTrue(method_exists($nestedQuery, 'addParameter'), 'Nested query must have addParameter method');
-        $this->assertTrue(method_exists($nestedQuery, 'setParameters'), 'Nested query must have setParameters method');
-        $this->assertTrue(method_exists($nestedQuery, 'getParameters'), 'Nested query must have getParameters method');
-        $this->assertTrue(method_exists($nestedQuery, 'hasParameter'), 'Nested query must have hasParameter method');
-        $this->assertTrue(method_exists($nestedQuery, 'getParameter'), 'Nested query must have getParameter method');
+        $query = new TermsQuery('foo', 'bar');
+        $query = new NestedQuery($path, $query, $parameters);
+        $result = $query->toArray();
+        $this->assertEquals($expected, $result);
     }
 
     /**

--- a/tests/Query/NestedQueryTest.php
+++ b/tests/Query/NestedQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+namespace ONGR\ElasticsearchDSL\Tests\Query;
 
 use ONGR\ElasticsearchDSL\Query\BoolQuery;
 use ONGR\ElasticsearchDSL\Query\NestedQuery;

--- a/tests/Query/ScriptQueryTest.php
+++ b/tests/Query/ScriptQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+namespace ONGR\ElasticsearchDSL\Tests\Query;
 
 use ONGR\ElasticsearchDSL\Query\ScriptQuery;
 

--- a/tests/Query/ScriptQueryTest.php
+++ b/tests/Query/ScriptQueryTest.php
@@ -1,0 +1,54 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+
+use ONGR\ElasticsearchDSL\Query\ScriptQuery;
+
+class ScriptQueryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Data provider for testToArray().
+     *
+     * @return array
+     */
+    public function getArrayDataProvider()
+    {
+        return [
+            'simple_script' => [
+                "doc['num1'].value > 1",
+                [],
+                ['script' => ['inline' => "doc['num1'].value > 1"]],
+            ],
+            'script_with_parameters' => [
+                "doc['num1'].value > param1",
+                ['params' => ['param1' => 5]],
+                ['script' => ['inline' => "doc['num1'].value > param1", 'params' => ['param1' => 5]]],
+            ],
+        ];
+    }
+
+    /**
+     * Test for filter toArray() method.
+     *
+     * @param string $script     Script.
+     * @param array  $parameters Optional parameters.
+     * @param array  $expected   Expected values.
+     *
+     * @dataProvider getArrayDataProvider
+     */
+    public function testToArray($script, $parameters, $expected)
+    {
+        $filter = new ScriptQuery($script, $parameters);
+        $result = $filter->toArray();
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/Query/Span/SpanFirstQueryTest.php
+++ b/tests/Query/Span/SpanFirstQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query\Span;
+namespace ONGR\ElasticsearchDSL\Tests\Query\Span;
 
 use ONGR\ElasticsearchDSL\Query\Span\SpanFirstQuery;
 use ONGR\ElasticsearchDSL\Query\Span\SpanQueryInterface;

--- a/tests/Query/Span/SpanMultiTermQueryTest.php
+++ b/tests/Query/Span/SpanMultiTermQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query\Span;
+namespace ONGR\ElasticsearchDSL\Tests\Query\Span;
 
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\Query\Span\SpanMultiTermQuery;

--- a/tests/Query/Span/SpanNearQueryTest.php
+++ b/tests/Query/Span/SpanNearQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query\Span;
+namespace ONGR\ElasticsearchDSL\Tests\Query\Span;
 
 use ONGR\ElasticsearchDSL\Query\Span\SpanNearQuery;
 use ONGR\ElasticsearchDSL\Query\Span\SpanQueryInterface;

--- a/tests/Query/Span/SpanNotQueryTest.php
+++ b/tests/Query/Span/SpanNotQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query\Span;
+namespace ONGR\ElasticsearchDSL\Tests\Query\Span;
 
 use ONGR\ElasticsearchDSL\Query\Span\SpanNotQuery;
 use ONGR\ElasticsearchDSL\Query\Span\SpanQueryInterface;

--- a/tests/Query/Span/SpanOrQueryTest.php
+++ b/tests/Query/Span/SpanOrQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query\Span;
+namespace ONGR\ElasticsearchDSL\Tests\Query\Span;
 
 use ONGR\ElasticsearchDSL\Query\Span\SpanOrQuery;
 use ONGR\ElasticsearchDSL\Query\Span\SpanQueryInterface;

--- a/tests/Query/Span/SpanTermQueryTest.php
+++ b/tests/Query/Span/SpanTermQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query\Span;
+namespace ONGR\ElasticsearchDSL\Tests\Query\Span;
 
 use ONGR\ElasticsearchDSL\Query\Span\SpanTermQuery;
 

--- a/tests/Query/TypeQueryTest.php
+++ b/tests/Query/TypeQueryTest.php
@@ -1,0 +1,27 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+
+use ONGR\ElasticsearchDSL\Query\TypeQuery;
+
+class TypeQueryTest extends \PHPUnit_Framework_TestCase
+{
+    /**
+     * Test for query toArray() method.
+     */
+    public function testToArray()
+    {
+        $query = new TypeQuery('foo');
+        $expectedResult = ['value' => 'foo'];
+        $this->assertEquals($expectedResult, $query->toArray());
+    }
+}

--- a/tests/Query/TypeQueryTest.php
+++ b/tests/Query/TypeQueryTest.php
@@ -9,7 +9,7 @@
  * file that was distributed with this source code.
  */
 
-namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
+namespace ONGR\ElasticsearchDSL\Tests\Query;
 
 use ONGR\ElasticsearchDSL\Query\TypeQuery;
 


### PR DESCRIPTION
Blocked by #48

What was done:

- Deprecated all filters
- Deprecated filtered query
- Fixed range filter (parameters were added in wrong scope)
- Fixed namespace of test classes

What should be done next:

- Add “deprecated” in filters documentation
- Add documentation for new queries
- Update places where deprecated filters are used

Notes:

Deprecated classes now throws `E_USER_DEPRECATED` error. Because `trigger_error()` was used in file scope, CodeSniffer now shows warnings on these lines.
