### PR TITLE
Fix nested query in case "bool" with single "must" given

### DIFF
--- a/src/Aggregation/FilterAggregation.php
+++ b/src/Aggregation/FilterAggregation.php
@@ -69,13 +69,7 @@ class FilterAggregation extends AbstractAggregation
             throw new \LogicException("Filter aggregation `{$this->getName()}` has no filter added");
         }
 
-        if ($this->filter instanceof BoolFilter && $this->filter->isRelevant()
-            || !$this->filter instanceof BoolFilter
-        ) {
-            $filterData = [$this->filter->getType() => $this->filter->toArray()];
-        } else {
-            $filterData = $this->filter->toArray();
-        }
+        $filterData = [$this->filter->getType() => $this->filter->toArray()];
 
         return $filterData;
     }

--- a/src/Query/BoolQuery.php
+++ b/src/Query/BoolQuery.php
@@ -30,30 +30,26 @@ class BoolQuery implements BuilderInterface
     /**
      * @var array
      */
-    private $container = [];
+    private $container;
 
     /**
      * Constructor to prepare container.
      */
     public function __construct()
     {
-        $this->container = [
-            self::MUST => [],
-            self::MUST_NOT => [],
-            self::SHOULD => [],
-        ];
+        $this->container = [];
     }
 
     /**
      * Checks if bool expression is relevant.
      *
      * @return bool
+     *
+     * @deprecated Will be removed in 2.0. No replacement. Always use full structure.
      */
     public function isRelevant()
     {
-        return
-            (count($this->container[self::MUST_NOT]) + count($this->container[self::SHOULD])) > 0
-            || count($this->container[self::MUST]) > 1;
+        return true;
     }
 
     /**
@@ -63,11 +59,13 @@ class BoolQuery implements BuilderInterface
     public function getQueries($boolType = null)
     {
         if ($boolType === null) {
-            return array_merge(
-                $this->container[self::MUST],
-                $this->container[self::MUST_NOT],
-                $this->container[self::SHOULD]
-            );
+            $queries = [];
+
+            foreach ($this->container as $item) {
+                $queries = array_merge($queries, $item);
+            }
+
+            return $queries;
         }
 
         return $this->container[$boolType];
@@ -104,15 +102,7 @@ class BoolQuery implements BuilderInterface
      */
     public function toArray()
     {
-        $output = $this->processArray();
-
-        if (!$this->isRelevant()) {
-            /** @var BuilderInterface $query */
-            $mustContainer = $this->container[self::MUST];
-            $query = array_shift($mustContainer);
-
-            return [$query->getType() => $query->toArray()];
-        }
+        $output = [];
 
         foreach ($this->container as $boolType => $builders) {
             /** @var BuilderInterface $builder */

--- a/src/SearchEndpoint/FilterEndpoint.php
+++ b/src/SearchEndpoint/FilterEndpoint.php
@@ -35,14 +35,8 @@ class FilterEndpoint extends QueryEndpoint
         }
 
         $query = new FilteredQuery();
-        if (!$this->getBool()->isRelevant()) {
-            $filters = $this->getBool()->getQueries(BoolFilter::MUST);
-            $filter = array_shift($filters);
-        } else {
-            $filter = $this->getBool();
-        }
+        $query->setFilter($this->getBool());
 
-        $query->setFilter($filter);
         $this->addReference('filtered_query', $query);
     }
 

--- a/src/SearchEndpoint/PostFilterEndpoint.php
+++ b/src/SearchEndpoint/PostFilterEndpoint.php
@@ -33,12 +33,7 @@ class PostFilterEndpoint extends FilterEndpoint
             return null;
         }
 
-        if (!$this->getBool()->isRelevant()) {
-            $filters = $this->getBool()->getQueries(BoolFilter::MUST);
-            $filter = array_shift($filters);
-        } else {
-            $filter = $this->getBool();
-        }
+        $filter = $this->getBool();
 
         return [$filter->getType() => $filter->toArray()];
     }

--- a/src/SearchEndpoint/QueryEndpoint.php
+++ b/src/SearchEndpoint/QueryEndpoint.php
@@ -51,10 +51,7 @@ class QueryEndpoint extends AbstractSearchEndpoint implements OrderedNormalizerI
         }
 
         $queryArray = $this->bool->toArray();
-
-        if ($this->bool->isRelevant()) {
-            $queryArray = [$this->bool->getType() => $queryArray];
-        }
+        $queryArray = [$this->bool->getType() => $queryArray];
 
         return $queryArray;
     }

--- a/tests/Query/BoolQueryTest.php
+++ b/tests/Query/BoolQueryTest.php
@@ -23,40 +23,11 @@ class BoolQueryTest extends \PHPUnit_Framework_TestCase
     /**
      * Tests isRelevant method.
      */
-    public function testBoolIsRelevantWithOneQuery()
+    public function testIsRelevant()
     {
         $bool = new BoolQuery();
-        $this->assertFalse($bool->isRelevant());
-        $bool->add(new TermQuery('acme', 'foo'));
-
-        $this->assertFalse($bool->isRelevant());
-    }
-
-    /**
-     * Tests isRelevant method when there is query added to should case.
-     */
-    public function testBoolIsRelevantWithOneShouldQuery()
-    {
-        $bool = new BoolQuery();
-        $this->assertFalse($bool->isRelevant());
-        $bool->add(new TermQuery('acme', 'foo'), BoolQuery::SHOULD);
-
         $this->assertTrue($bool->isRelevant());
     }
-
-    /**
-     * Tests isRelevant method with 2 queries.
-     */
-    public function testBoolIsRelevantWithTwoQuery()
-    {
-        $bool = new BoolQuery();
-        $this->assertFalse($bool->isRelevant());
-        $bool->add(new TermQuery('acme', 'foo'));
-        $bool->add(new TermQuery('bar', 'go'));
-
-        $this->assertTrue($bool->isRelevant());
-    }
-
     /**
      * Test for addToBool() without setting a correct bool operator.
      *

--- a/tests/Query/NestedQueryTest.php
+++ b/tests/Query/NestedQueryTest.php
@@ -11,7 +11,9 @@
 
 namespace ONGR\ElasticsearchDSL\Tests\Unit\DSL\Query;
 
+use ONGR\ElasticsearchDSL\Query\BoolQuery;
 use ONGR\ElasticsearchDSL\Query\NestedQuery;
+use ONGR\ElasticsearchDSL\Query\TermQuery;
 
 class NestedQueryTest extends \PHPUnit_Framework_TestCase
 {
@@ -56,5 +58,31 @@ class NestedQueryTest extends \PHPUnit_Framework_TestCase
         $this->assertTrue(method_exists($nestedQuery, 'getParameters'), 'Nested query must have getParameters method');
         $this->assertTrue(method_exists($nestedQuery, 'hasParameter'), 'Nested query must have hasParameter method');
         $this->assertTrue(method_exists($nestedQuery, 'getParameter'), 'Nested query must have getParameter method');
+    }
+
+    /**
+     * Test for toArray() in case bool with single clause given.
+     */
+    public function testSingleBoolMust()
+    {
+        $bool = new BoolQuery();
+        $bool->add(new TermQuery('field1', 'value1'));
+
+        $query = new NestedQuery('obj1', $bool);
+
+        $expected = [
+            'path' => 'obj1',
+            'query' => [
+                'bool' => [
+                    'must' => [
+                        [
+                            'term' => ['field1' => 'value1'],
+                        ],
+                    ],
+                ],
+            ],
+        ];
+
+        $this->assertEquals($expected, $query->toArray());
     }
 }

--- a/tests/SearchEndpoint/FilterEndpointTest.php
+++ b/tests/SearchEndpoint/FilterEndpointTest.php
@@ -64,7 +64,15 @@ class FilterEndpointTest extends \PHPUnit_Framework_TestCase
         /** @var FilteredQuery $reference */
         $reference = $instance->getReference('filtered_query');
         $this->assertInstanceOf('ONGR\ElasticsearchDSL\Query\FilteredQuery', $reference);
-        $this->assertSame($matchAllFilter, $reference->getFilter());
+
+        /** @var \ONGR\ElasticsearchDSL\Query\BoolQuery $bool */
+        $bool = $reference->getFilter();
+        $this->assertInstanceOf('ONGR\ElasticsearchDSL\Query\BoolQuery', $bool);
+
+        $must = $bool->getQueries('must');
+        $realReference = reset($must);
+
+        $this->assertSame($matchAllFilter, $realReference);
     }
 
     /**

--- a/tests/SearchEndpoint/PostFilterEndpointTest.php
+++ b/tests/SearchEndpoint/PostFilterEndpointTest.php
@@ -54,7 +54,7 @@ class PostFilterEndpointTest extends \PHPUnit_Framework_TestCase
         $instance->add($matchAll);
 
         $this->assertEquals(
-            json_encode([$matchAll->getType() => $matchAll->toArray()]),
+            json_encode(['bool' => ['must' => [[$matchAll->getType() => $matchAll->toArray()]]]]),
             json_encode($instance->normalize($normalizerInterface))
         );
     }

--- a/tests/SearchEndpoint/QueryEndpointTest.php
+++ b/tests/SearchEndpoint/QueryEndpointTest.php
@@ -55,7 +55,7 @@ class QueryEndpointTest extends \PHPUnit_Framework_TestCase
         $instance->add($matchAll);
 
         $this->assertEquals(
-            [$matchAll->getType() => $matchAll->toArray()],
+            ['bool' => ['must' => [[$matchAll->getType() => $matchAll->toArray()]]]],
             $instance->normalize($normalizerInterface)
         );
     }


### PR DESCRIPTION
Fixes #32

This PR deprecates `BoolQuery::isRelevant()` because it complicates everything. Too many places uses that complicated logic. Idea is "keep things simple, use single (full) query structure".

After these changes queries with single must bool will look like this:

```json
{"bool":{"must":[{"match_all":[]}]}}
```

Instead of this:

```json
{"match_all":[]}
```

Both ways are valid and equal. This does not influence results returned by Elasticsearch.

In the future we could simplify structure again, BUT only if we could do that in `BoolQuery` itself. That would be a BC break. I think each query class itself should return full array (`[type=>data_array]`).

Please merge this only after #48 is merged.