### PR TITLE
Do not set filtered query into query endpoint during normalization

### DIFF
--- a/src/SearchEndpoint/QueryEndpoint.php
+++ b/src/SearchEndpoint/QueryEndpoint.php
@@ -40,20 +40,24 @@ class QueryEndpoint extends AbstractSearchEndpoint implements OrderedNormalizerI
      */
     public function normalize(NormalizerInterface $normalizer, $format = null, array $context = [])
     {
+        $query = $this->getBool();
+
         if ($this->hasReference('filtered_query')) {
             /** @var FilteredQuery $filteredQuery */
             $filteredQuery = $this->getReference('filtered_query');
-            $this->add($filteredQuery);
+
+            if ($query) {
+                $filteredQuery->setQuery($query);
+            }
+
+            $query = $filteredQuery;
         }
 
-        if (!$this->bool) {
+        if (!$query) {
             return null;
         }
 
-        $queryArray = $this->bool->toArray();
-        $queryArray = [$this->bool->getType() => $queryArray];
-
-        return $queryArray;
+        return [$query->getType() => $query->toArray()];
     }
 
     /**


### PR DESCRIPTION
Follows https://github.com/ongr-io/ElasticsearchBundle/pull/543