### PR TITLE
[Proposal] Do not add prefix for aggregation names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 CHANGELOG
 =========
 
-v1.x (201x)
+v2.0.0 (2016-x)
 ---
 
+- [BC break] Aggregation name is not prefixed anymore
 
 v1.1.0 (2015-12-28)
 ---

--- a/src/Aggregation/AbstractAggregation.php
+++ b/src/Aggregation/AbstractAggregation.php
@@ -24,8 +24,6 @@ abstract class AbstractAggregation implements BuilderInterface
     use ParametersTrait;
     use NameAwareTrait;
 
-    const PREFIX = 'agg_';
-
     /**
      * @var string
      */
@@ -55,7 +53,7 @@ abstract class AbstractAggregation implements BuilderInterface
      */
     public function __construct($name)
     {
-        $this->setName(self::PREFIX.$name);
+        $this->setName($name);
     }
 
     /**
@@ -110,8 +108,8 @@ abstract class AbstractAggregation implements BuilderInterface
      */
     public function getAggregation($name)
     {
-        if ($this->aggregations && $this->aggregations->has(self::PREFIX.$name)) {
-            return $this->aggregations->get(self::PREFIX.$name);
+        if ($this->aggregations && $this->aggregations->has($name)) {
+            return $this->aggregations->get($name);
         } else {
             return null;
         }

--- a/src/SearchEndpoint/FilterEndpoint.php
+++ b/src/SearchEndpoint/FilterEndpoint.php
@@ -11,7 +11,7 @@
 
 namespace ONGR\ElasticsearchDSL\SearchEndpoint;
 
-use ONGR\ElasticsearchDSL\Filter\BoolFilter;
+use ONGR\ElasticsearchDSL\Query\BoolQuery;
 use ONGR\ElasticsearchDSL\Query\FilteredQuery;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -51,10 +51,10 @@ class FilterEndpoint extends QueryEndpoint
     /**
      * Returns bool instance for this endpoint case.
      *
-     * @return BoolFilter
+     * @return BoolQuery
      */
     protected function getBoolInstance()
     {
-        return new BoolFilter();
+        return new BoolQuery();
     }
 }

--- a/tests/Aggregation/FilterAggregationTest.php
+++ b/tests/Aggregation/FilterAggregationTest.php
@@ -11,14 +11,12 @@
 
 namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
-use ONGR\ElasticsearchDSL\Aggregation\AbstractAggregation;
 use ONGR\ElasticsearchDSL\Aggregation\FilterAggregation;
 use ONGR\ElasticsearchDSL\Aggregation\HistogramAggregation;
-use ONGR\ElasticsearchDSL\BuilderInterface;
-use ONGR\ElasticsearchDSL\Filter\BoolFilter;
-use ONGR\ElasticsearchDSL\Filter\MatchAllFilter;
-use ONGR\ElasticsearchDSL\Filter\MissingFilter;
 use ONGR\ElasticsearchDSL\Filter\TermFilter;
+use ONGR\ElasticsearchDSL\Query\BoolQuery;
+use ONGR\ElasticsearchDSL\Query\MatchAllQuery;
+use ONGR\ElasticsearchDSL\Query\MissingQuery;
 
 class FilterAggregationTest extends \PHPUnit_Framework_TestCase
 {
@@ -33,7 +31,7 @@ class FilterAggregationTest extends \PHPUnit_Framework_TestCase
 
         // Case #0 filter aggregation.
         $aggregation = new FilterAggregation('test_agg');
-        $filter = new MatchAllFilter();
+        $filter = new MatchAllQuery();
 
         $aggregation->setFilter($filter);
 
@@ -71,9 +69,9 @@ class FilterAggregationTest extends \PHPUnit_Framework_TestCase
 
         // Case #2 testing bool filter.
         $aggregation = new FilterAggregation('test_agg');
-        $matchAllFilter = new MatchAllFilter();
+        $matchAllFilter = new MatchAllQuery();
         $termFilter = new TermFilter('acme', 'foo');
-        $boolFilter = new BoolFilter();
+        $boolFilter = new BoolQuery();
         $boolFilter->add($matchAllFilter);
         $boolFilter->add($termFilter);
 
@@ -138,7 +136,7 @@ class FilterAggregationTest extends \PHPUnit_Framework_TestCase
     {
         $aggregation = new FilterAggregation('test_agg');
 
-        $aggregation->setFilter(new MissingFilter('test'));
+        $aggregation->setFilter(new MissingQuery('test'));
         $aggregation->toArray();
     }
 
@@ -147,7 +145,7 @@ class FilterAggregationTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorFilter()
     {
-        $matchAllFilter = new MatchAllFilter();
+        $matchAllFilter = new MatchAllQuery();
         $aggregation = new FilterAggregation('test', $matchAllFilter);
         $this->assertSame(
             [

--- a/tests/Aggregation/NestedAggregationTest.php
+++ b/tests/Aggregation/NestedAggregationTest.php
@@ -11,7 +11,6 @@
 
 namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
-use ONGR\ElasticsearchDSL\Aggregation\AbstractAggregation;
 use ONGR\ElasticsearchDSL\Aggregation\NestedAggregation;
 use ONGR\ElasticsearchDSL\Aggregation\TermsAggregation;
 
@@ -26,14 +25,7 @@ class NestedAggregationTest extends \PHPUnit_Framework_TestCase
     {
         $aggregation = new NestedAggregation('test_agg');
         $aggregation->setPath('test_path');
-
-        $expectedResult = [
-            AbstractAggregation::PREFIX.'test_agg' => [
-                'nested' => ['path' => 'test_path'],
-            ],
-        ];
-
-        $this->assertEquals($expectedResult, $aggregation->toArray());
+        $aggregation->toArray();
     }
 
     /**

--- a/tests/Aggregation/RangeAggregationTest.php
+++ b/tests/Aggregation/RangeAggregationTest.php
@@ -98,7 +98,7 @@ class RangeAggregationTest extends \PHPUnit_Framework_TestCase
                 'keyed' => false,
             ],
             'aggregations' => [
-                AbstractAggregation::PREFIX.'test_agg_2' => [
+                'test_agg_2' => [
                     'range' => [
                         'ranges' => [
                             [


### PR DESCRIPTION
Please note, this is partial __BC break__. Output now wont have `agg_` prefix. This should not affect users who were using `PREFIX` constant.