### PR TITLE
Deprecate filter/query detection traits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,10 @@
 CHANGELOG
 =========
 
-v1.x (201x)
+v1.1.x (2016-x)
 ---
 
+- Deprecated `DslTypeAwareTrait` and `FilterOrQueryDetectionTrait` traits
 
 v1.1.0 (2015-12-28)
 ---

--- a/docs/HowTo/HowToSearch.md
+++ b/docs/HowTo/HowToSearch.md
@@ -43,16 +43,22 @@ At the end it will form this query:
 
 ### Form a Filter
 
+> Since Elasticsearch 2.0 all filters were replaced by queries. Queries acts like
+> filters when you use them in filter context. For easier future migration use query
+> classes instead of filter. (Note, for Elasticsearch 1.* you still should use `ScriptFilter`,
+> `HasChildFilter`, `HasParentFilter`, `IndicesFilter`, `NestedFilter`, `PrefixFilter`,
+> `RegexpFilter`, `TermFilter` instead of query as they has different structure.)
+
 To add a filter is the same way like a query. First, lets create some `Filter` object.
 
 ```php
-$matchAllFilter = new MatchAllFilter();
+$matchAllQuery = new MatchAllQuery();
 ```
 
 And simply add to the `Search`:
 
 ```php
-$search->addFilter($matchAllFilter);
+$search->addFilter($matchAllQuery);
 ```
 
 Unlike `Query`, when we add a `Filter` with our DSL library it will add a query and all necessary stuff for you. So when we add one filter we will get this query:
@@ -115,8 +121,8 @@ The same way it works with a `Filter`. Take a look at this example:
 ```php
 $search = new Search();
 $termFilter = new TermFilter('name', 'ongr');
-$missingFilter = new MissingFilter('disabled');
-$existsFilter = new ExistsFilter('tag');
+$missingFilter = new MissingQuery('disabled');
+$existsFilter = new ExistsQuery('tag');
 $search->addFilter($termFilter);
 $search->addFilter($missingFilter);
 $search->addFilter($existsFilter, BoolQuery::MUST_NOT);

--- a/docs/Query/Filtered.md
+++ b/docs/Query/Filtered.md
@@ -1,5 +1,7 @@
 # Filtered query
 
+__DEPRECATED__: filtered query is deprecated and will be removed in ElasticsearchDSL 2.0
+
 > More info about filtered query is in the [official elasticsearch docs][1]
 
 The filtered query is used to combine another query with any filter. Filters are usually faster than queries.

--- a/src/BuilderInterface.php
+++ b/src/BuilderInterface.php
@@ -19,6 +19,9 @@ interface BuilderInterface
     /**
      * Generates array which will be passed to elasticsearch-php client.
      *
+     * WARNING: the output of this method will change in version v2.0. It will
+     * always return array WITH query/aggregation type as key.
+     *
      * @return array|object
      */
     public function toArray();

--- a/src/DslTypeAwareTrait.php
+++ b/src/DslTypeAwareTrait.php
@@ -13,6 +13,8 @@ namespace ONGR\ElasticsearchDSL;
 
 /**
  * A trait which handles dsl type.
+ *
+ * @deprecated Will be removed in 2.0.
  */
 trait DslTypeAwareTrait
 {

--- a/src/FilterOrQueryDetectionTrait.php
+++ b/src/FilterOrQueryDetectionTrait.php
@@ -13,6 +13,8 @@ namespace ONGR\ElasticsearchDSL;
 
 /**
  * A trait which can detect query or filter is passed.
+ *
+ * @deprecated Will be removed in 2.0.
  */
 trait FilterOrQueryDetectionTrait
 {

--- a/src/Query/TypeQuery.php
+++ b/src/Query/TypeQuery.php
@@ -18,7 +18,7 @@ use ONGR\ElasticsearchDSL\BuilderInterface;
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-type-query.html
  */
-class TypeQuery implements BuilderInterface  // TODO: add test
+class TypeQuery implements BuilderInterface
 {
     /**
      * @var string

--- a/src/Search.php
+++ b/src/Search.php
@@ -221,7 +221,9 @@ class Search
      */
     public function addFilter(BuilderInterface $filter, $boolType = BoolQuery::MUST, $key = null)
     {
+        // Trigger creation of QueryEndpoint as filters depends on it
         $this->getEndpoint(QueryEndpoint::NAME);
+
         $endpoint = $this->getEndpoint(FilterEndpoint::NAME);
         $endpoint->addToBool($filter, $boolType, $key);
 

--- a/src/SearchEndpoint/FilterEndpoint.php
+++ b/src/SearchEndpoint/FilterEndpoint.php
@@ -11,7 +11,6 @@
 
 namespace ONGR\ElasticsearchDSL\SearchEndpoint;
 
-use ONGR\ElasticsearchDSL\Filter\BoolFilter;
 use ONGR\ElasticsearchDSL\Query\FilteredQuery;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 
@@ -46,15 +45,5 @@ class FilterEndpoint extends QueryEndpoint
     public function getOrder()
     {
         return 1;
-    }
-
-    /**
-     * Returns bool instance for this endpoint case.
-     *
-     * @return BoolFilter
-     */
-    protected function getBoolInstance()
-    {
-        return new BoolFilter();
     }
 }

--- a/tests/Aggregation/FilterAggregationTest.php
+++ b/tests/Aggregation/FilterAggregationTest.php
@@ -11,13 +11,11 @@
 
 namespace ONGR\ElasticsearchDSL\Tests\Aggregation;
 
-use ONGR\ElasticsearchDSL\Aggregation\AbstractAggregation;
 use ONGR\ElasticsearchDSL\Aggregation\FilterAggregation;
 use ONGR\ElasticsearchDSL\Aggregation\HistogramAggregation;
-use ONGR\ElasticsearchDSL\BuilderInterface;
-use ONGR\ElasticsearchDSL\Filter\BoolFilter;
-use ONGR\ElasticsearchDSL\Filter\MatchAllFilter;
-use ONGR\ElasticsearchDSL\Filter\MissingFilter;
+use ONGR\ElasticsearchDSL\Query\BoolQuery;
+use ONGR\ElasticsearchDSL\Query\MatchAllQuery;
+use ONGR\ElasticsearchDSL\Query\MissingQuery;
 use ONGR\ElasticsearchDSL\Filter\TermFilter;
 
 class FilterAggregationTest extends \PHPUnit_Framework_TestCase
@@ -33,7 +31,7 @@ class FilterAggregationTest extends \PHPUnit_Framework_TestCase
 
         // Case #0 filter aggregation.
         $aggregation = new FilterAggregation('test_agg');
-        $filter = new MatchAllFilter();
+        $filter = new MatchAllQuery();
 
         $aggregation->setFilter($filter);
 
@@ -71,9 +69,9 @@ class FilterAggregationTest extends \PHPUnit_Framework_TestCase
 
         // Case #2 testing bool filter.
         $aggregation = new FilterAggregation('test_agg');
-        $matchAllFilter = new MatchAllFilter();
+        $matchAllFilter = new MatchAllQuery();
         $termFilter = new TermFilter('acme', 'foo');
-        $boolFilter = new BoolFilter();
+        $boolFilter = new BoolQuery();
         $boolFilter->add($matchAllFilter);
         $boolFilter->add($termFilter);
 
@@ -138,7 +136,7 @@ class FilterAggregationTest extends \PHPUnit_Framework_TestCase
     {
         $aggregation = new FilterAggregation('test_agg');
 
-        $aggregation->setFilter(new MissingFilter('test'));
+        $aggregation->setFilter(new MissingQuery('test'));
         $aggregation->toArray();
     }
 
@@ -147,7 +145,7 @@ class FilterAggregationTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructorFilter()
     {
-        $matchAllFilter = new MatchAllFilter();
+        $matchAllFilter = new MatchAllQuery();
         $aggregation = new FilterAggregation('test', $matchAllFilter);
         $this->assertSame(
             [

--- a/tests/Query/GeoBoundingBoxQueryTest.php
+++ b/tests/Query/GeoBoundingBoxQueryTest.php
@@ -11,7 +11,7 @@
 
 namespace ONGR\ElasticsearchDSL\Tests\Query;
 
-use ONGR\ElasticsearchDSL\Filter\GeoBoundingBoxFilter;
+use ONGR\ElasticsearchDSL\Query\GeoBoundingBoxQuery;
 
 class GeoBoundingBoxQueryTest extends \PHPUnit_Framework_TestCase
 {
@@ -20,10 +20,10 @@ class GeoBoundingBoxQueryTest extends \PHPUnit_Framework_TestCase
      *
      * @expectedException \LogicException
      */
-    public function testGeoBoundBoxFilterException()
+    public function testGeoBoundBoxQueryException()
     {
-        $filter = new GeoBoundingBoxFilter('location', []);
-        $filter->toArray();
+        $query = new GeoBoundingBoxQuery('location', []);
+        $query->toArray();
     }
 
     /**
@@ -80,8 +80,8 @@ class GeoBoundingBoxQueryTest extends \PHPUnit_Framework_TestCase
      */
     public function testToArray($field, $values, $parameters, $expected)
     {
-        $filter = new GeoBoundingBoxFilter($field, $values, $parameters);
-        $result = $filter->toArray();
+        $query = new GeoBoundingBoxQuery($field, $values, $parameters);
+        $result = $query->toArray();
         $this->assertEquals($expected, $result);
     }
 }

--- a/tests/Query/HasChildQueryTest.php
+++ b/tests/Query/HasChildQueryTest.php
@@ -20,10 +20,8 @@ class HasChildQueryTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructor()
     {
-        $missingFilterMock = $this->getMockBuilder('ONGR\ElasticsearchDSL\Filter\MissingFilter')
-            ->setConstructorArgs(['test_field'])
-            ->getMock();
-        $query = new HasChildQuery('test_type', $missingFilterMock, ['test_parameter1']);
+        $childQuery = $this->getMock('ONGR\ElasticsearchDSL\BuilderInterface');
+        $query = new HasChildQuery('test_type', $childQuery, ['test_parameter1']);
         $this->assertEquals(['test_parameter1'], $query->getParameters());
     }
 }

--- a/tests/Query/HasParentQueryTest.php
+++ b/tests/Query/HasParentQueryTest.php
@@ -20,10 +20,8 @@ class HasParentQueryTest extends \PHPUnit_Framework_TestCase
      */
     public function testConstructor()
     {
-        $missingFilter = $this->getMockBuilder('ONGR\ElasticsearchDSL\Filter\MissingFilter')
-            ->setConstructorArgs(['test_field'])
-            ->getMock();
-        $query = new HasParentQuery('test_type', $missingFilter, ['test_parameter1']);
+        $parentQuery = $this->getMock('ONGR\ElasticsearchDSL\BuilderInterface');
+        $query = new HasParentQuery('test_type', $parentQuery, ['test_parameter1']);
         $this->assertEquals(['test_parameter1'], $query->getParameters());
     }
 }

--- a/tests/SearchEndpoint/FilterEndpointTest.php
+++ b/tests/SearchEndpoint/FilterEndpointTest.php
@@ -11,8 +11,8 @@
 
 namespace ONGR\ElasticsearchDSL\Tests\Unit\SearchEndpoint;
 
-use ONGR\ElasticsearchDSL\Filter\MatchAllFilter;
 use ONGR\ElasticsearchDSL\Query\FilteredQuery;
+use ONGR\ElasticsearchDSL\Query\MatchAllQuery;
 use ONGR\ElasticsearchDSL\SearchEndpoint\FilterEndpoint;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
@@ -55,7 +55,7 @@ class FilterEndpointTest extends \PHPUnit_Framework_TestCase
         $this->assertNull($instance->normalize($normalizerInterface));
         $this->assertFalse($instance->hasReference('filtered_query'));
 
-        $matchAllFilter = new MatchAllFilter();
+        $matchAllFilter = new MatchAllQuery();
         $instance->add($matchAllFilter);
 
         $this->assertNull($instance->normalize($normalizerInterface));
@@ -81,7 +81,7 @@ class FilterEndpointTest extends \PHPUnit_Framework_TestCase
     public function testEndpointGetter()
     {
         $filterName = 'acme_filter';
-        $filter = new MatchAllFilter();
+        $filter = new MatchAllQuery();
         $endpoint = new FilterEndpoint();
         $endpoint->add($filter, $filterName);
         $builders = $endpoint->getAll();

--- a/tests/SearchEndpoint/PostFilterEndpointTest.php
+++ b/tests/SearchEndpoint/PostFilterEndpointTest.php
@@ -11,7 +11,7 @@
 
 namespace ONGR\ElasticsearchDSL\Tests\Unit\SearchEndpoint;
 
-use ONGR\ElasticsearchDSL\Filter\MatchAllFilter;
+use ONGR\ElasticsearchDSL\Query\MatchAllQuery;
 use ONGR\ElasticsearchDSL\SearchEndpoint\PostFilterEndpoint;
 use Symfony\Component\Serializer\Normalizer\NormalizerInterface;
 use PHPUnit_Framework_MockObject_MockObject as MockObject;
@@ -50,7 +50,7 @@ class PostFilterEndpointTest extends \PHPUnit_Framework_TestCase
         );
         $this->assertNull($instance->normalize($normalizerInterface));
 
-        $matchAll = new MatchAllFilter();
+        $matchAll = new MatchAllQuery();
         $instance->add($matchAll);
 
         $this->assertEquals(
@@ -65,7 +65,7 @@ class PostFilterEndpointTest extends \PHPUnit_Framework_TestCase
     public function testEndpointGetter()
     {
         $filterName = 'acme_post_filter';
-        $filter = new MatchAllFilter();
+        $filter = new MatchAllQuery();
 
         $endpoint = new PostFilterEndpoint();
         $endpoint->add($filter, $filterName);


### PR DESCRIPTION
- Deprecated `DslTypeAwareTrait` and `FilterOrQueryDetectionTrait` traits as they wont be needed after we remove filters.
- Fixed `GeoBoundingBoxQueryTest` as it was testing filter, not query.
- Replaced filter class usages with queries where possible.