### PR TITLE
Remove unused symfony/options-resolver dependency

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,8 +12,7 @@
     ],
     "require": {
         "php": ">=5.4",
-        "symfony/serializer": "~2.7|~3.0",
-        "symfony/options-resolver": "~2.7|~3.0"
+        "symfony/serializer": "~2.7|~3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.4",


### PR DESCRIPTION
Remove `symfony/options-resolver` dependency from composer.json as it's not used anywhere in the code. 