### PR TITLE
fix issue https://github.com/ongr-io/ElasticsearchDSL/issues/119 

### DIFF
--- a/src/Query/FunctionScoreQuery.php
+++ b/src/Query/FunctionScoreQuery.php
@@ -60,7 +60,7 @@ class FunctionScoreQuery implements BuilderInterface
     private function applyQuery(array &$function, BuilderInterface $query = null)
     {
         if ($query) {
-            $function['query'] = $query->toArray();
+            $function['filter'] = $query->toArray();
         }
     }
 


### PR DESCRIPTION
  
- [x] Fix error cannot create "filter" with weight for elastic search by function_score, instead of "query"
```javascript
"function_score": {
    "query": {},
    "boost": "boost for the whole query",
    "functions": [
        {
            "filter": {},
            "FUNCTION": {}, 
            "weight": number
        },
        ..........
```
- [x]  Function change:
- From
```
private function applyQuery(array &$function, BuilderInterface $query = null)
{
      if ($query) {
           $function['query'] = $query->toArray();
      }
}
```

- To

```
private function applyQuery(array &$function, BuilderInterface $query = null)
{
     if ($query) {
           $function['filter'] = $query->toArray();
      }
}
```
 