### PR TITLE
Remove Amazon Elasticsearch Service version warning

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ is the preffered and recommended way to ask ONGR support questions.
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/ongr-io/ElasticsearchDSL/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/ongr-io/ElasticsearchDSL/?branch=master)
 
 __This component requires Elasticsearch 2.0 or newer.__
-> Warning: If you are using Amazon Elasticsearch Service (currently supports only Elasticsearch 1.x) use Elasticsearch DSL 1.x version. 
 
 ## Documentation
 


### PR DESCRIPTION
Amazon Elasticsearch Service now supports Elasticsearch 2.3.
See: https://aws.amazon.com/about-aws/whats-new/2016/07/amazon-elasticsearch-service-now-supports-elasticsearch-2-3