### PR TITLE
Allow chaining of aggregation

### DIFF
--- a/src/Aggregation/AbstractAggregation.php
+++ b/src/Aggregation/AbstractAggregation.php
@@ -76,6 +76,8 @@ abstract class AbstractAggregation implements BuilderInterface
      * Adds a sub-aggregation.
      *
      * @param AbstractAggregation $abstractAggregation
+     *
+     * @return $this
      */
     public function addAggregation(AbstractAggregation $abstractAggregation)
     {
@@ -84,6 +86,8 @@ abstract class AbstractAggregation implements BuilderInterface
         }
 
         $this->aggregations->add($abstractAggregation);
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
With php7 new uniform syntax, we can do `(new Object())->call()`

This simple patch allow to avoid declare a variable for nested aggregation, and keep code more readable : 
```php
$query = (new Search())
    ->addAggregation(new TermsAggregation("country", 'organization_address.city'))
    ->addAggregation((new ChildrenAggregation("article", 'article'))
        ->addAggregation(new TermsAggregation("name", 'article_name.fr'))
        ->addAggregation((new NestedAggregation("kind", 'article_kind'))
            ->addAggregation(new TermsAggregation('name', 'kind_name.fr.original'))
        )
    );
```