### PR TITLE
InnerHit new implementation

### DIFF
--- a/docs/InnerHits/Nested.md
+++ b/docs/InnerHits/Nested.md
@@ -37,7 +37,9 @@ And now the query via DSL:
 ```php
 $matchQuery = new MatchQuery('comments.message', '[different query]');
 $nestedQuery = new NestedQuery('comments', $matchQuery);
-$innerHit = new NestedInnerHit('comment', 'comments', $matchQuery);
+$searchQuery = new Search();
+$searchQuery->add($matchQuery);
+$innerHit = new NestedInnerHit('comment', 'comments', $searchQuery);
 
 $search = new Search();
 $search->addQuery(new MatchQuery('comments.message', '[actual query]'));
@@ -98,10 +100,17 @@ And now the query via DSL:
 ```php
 
 $matchQuery = new MatchQuery('cars.manufacturers.country', 'Japan');
+$matchSearch = new Search();
+$matchSearch->addQuery($matchQuery);
+
 $nestedQuery = new NestedQuery('cars.manufacturers', $matchQuery);
-$innerHitNested = new NestedInnerHit('manufacturers', 'cars.manufacturers', $matchQuery);
-$innerHit = new NestedInnerHit('cars', 'cars', $nestedQuery);
-$innerHit->addInnerHit($innerHitNested);
+$nestedSearch = new Search();
+$nestedSearch->addQuery($nestedQuery);
+
+$innerHitNested = new NestedInnerHit('manufacturers', 'cars.manufacturers', $matchSearch);
+
+$innerHit = new NestedInnerHit('cars', 'cars', $nestedSearch);
+$nestedSearch->addInnerHit($innerHitNested);
 
 $search = new Search();
 $search->addInnerHit($innerHit);

--- a/src/InnerHit/NestedInnerHit.php
+++ b/src/InnerHit/NestedInnerHit.php
@@ -32,22 +32,24 @@ class NestedInnerHit implements BuilderInterface
     private $path;
 
     /**
-     * @var BuilderInterface
+     * @var Search
      */
-    private $query;
+    private $search;
 
     /**
      * Inner hits container init.
      *
      * @param string $name
      * @param string $path
-     * @param Search $query
+     * @param Search $search
      */
-    public function __construct($name, $path, Search $query = null)
+    public function __construct($name, $path, Search $search = null)
     {
         $this->setName($name);
         $this->setPath($path);
-        $this->setQuery($query);
+        if ($search) {
+            $this->setSearch($search);
+        }
     }
 
     /**
@@ -60,26 +62,34 @@ class NestedInnerHit implements BuilderInterface
 
     /**
      * @param string $path
+     *
+     * @return $this
      */
     public function setPath($path)
     {
         $this->path = $path;
+
+        return $this;
     }
 
     /**
-     * @return BuilderInterface
+     * @return Search
      */
-    public function getQuery()
+    public function getSearch()
     {
-        return $this->query;
+        return $this->search;
     }
 
     /**
-     * @param Search $query
+     * @param Search $search
+     *
+     * @return $this
      */
-    public function setQuery(Search $query = null)
+    public function setSearch(Search $search)
     {
-        $this->query = $query;
+        $this->search = $search;
+
+        return $this;
     }
 
     /**
@@ -95,7 +105,7 @@ class NestedInnerHit implements BuilderInterface
      */
     public function toArray()
     {
-        $out = $this->getQuery() ? $this->getQuery()->toArray() : new \stdClass();
+        $out = $this->getSearch() ? $this->getSearch()->toArray() : new \stdClass();
 
         $out = [
             $this->getPathType() => [

--- a/tests/InnerHit/NestedInnerHitTest.php
+++ b/tests/InnerHit/NestedInnerHitTest.php
@@ -111,10 +111,10 @@ class NestedInnerHitTest extends \PHPUnit_Framework_TestCase
         $hit = new NestedInnerHit('test', 'acme', new Search());
         $hit->setName('foo');
         $hit->setPath('bar');
-        $hit->setQuery($search);
+        $hit->setSearch($search);
 
         $this->assertEquals('foo', $hit->getName());
         $this->assertEquals('bar', $hit->getPath());
-        $this->assertEquals($search, $hit->getQuery());
+        $this->assertEquals($search, $hit->getSearch());
     }
 }

--- a/tests/InnerHit/NestedInnerHitTest.php
+++ b/tests/InnerHit/NestedInnerHitTest.php
@@ -5,7 +5,7 @@ namespace ONGR\ElasticsearchDSL\Tests\InnerHit;
 use ONGR\ElasticsearchDSL\InnerHit\NestedInnerHit;
 use ONGR\ElasticsearchDSL\Query\MatchQuery;
 use ONGR\ElasticsearchDSL\Query\NestedQuery;
-use ONGR\ElasticsearchDSL\Query\TermQuery;
+use ONGR\ElasticsearchDSL\Search;
 
 class NestedInnerHitTest extends \PHPUnit_Framework_TestCase
 {
@@ -20,11 +20,28 @@ class NestedInnerHitTest extends \PHPUnit_Framework_TestCase
 
         $matchQuery = new MatchQuery('foo.bar.aux', 'foo');
         $nestedQuery = new NestedQuery('foo.bar', $matchQuery);
-        $innerHit = new NestedInnerHit('acme', 'foo', $nestedQuery);
-        $nestedInnerHit1 = new NestedInnerHit('aux', 'foo.bar.aux', $matchQuery);
-        $nestedInnerHit2 = new NestedInnerHit('lux', 'foo.bar.aux', $matchQuery);
-        $innerHit->addInnerHit($nestedInnerHit1);
-        $innerHit->addInnerHit($nestedInnerHit2);
+        $searchQuery = new Search();
+        $searchQuery->addQuery($nestedQuery);
+
+        $matchSearch = new Search();
+        $matchSearch->addQuery($matchQuery);
+
+        $innerHit = new NestedInnerHit('acme', 'foo', $searchQuery);
+        $emptyInnerHit = new NestedInnerHit('acme', 'foo');
+
+        $nestedInnerHit1 = new NestedInnerHit('aux', 'foo.bar.aux', $matchSearch);
+        $nestedInnerHit2 = new NestedInnerHit('lux', 'foo.bar.aux', $matchSearch);
+        $searchQuery->addInnerHit($nestedInnerHit1);
+        $searchQuery->addInnerHit($nestedInnerHit2);
+
+        $out[] = [
+            $emptyInnerHit,
+            [
+                'path' => [
+                    'foo' => new \stdClass(),
+                ],
+            ],
+        ];
 
         $out[] = [
             $nestedInnerHit1,
@@ -88,30 +105,16 @@ class NestedInnerHitTest extends \PHPUnit_Framework_TestCase
     public function testGettersAndSetters()
     {
         $query = new MatchQuery('acme', 'test');
-        $hit = new NestedInnerHit('test', 'acme', new TermQuery('foo', 'bar'));
+        $search = new Search();
+        $search->addQuery($query);
+
+        $hit = new NestedInnerHit('test', 'acme', new Search());
         $hit->setName('foo');
         $hit->setPath('bar');
-        $hit->setQuery($query);
+        $hit->setQuery($search);
 
         $this->assertEquals('foo', $hit->getName());
         $this->assertEquals('bar', $hit->getPath());
-        $this->assertEquals($query, $hit->getQuery());
-    }
-
-    /**
-     * Tests getInnerHit() method
-     */
-    public function testGetInnerHit()
-    {
-        $query = new MatchQuery('acme', 'test');
-        $hit = new NestedInnerHit('test', 'acme', $query);
-        $nestedInnerHit1 = new NestedInnerHit('foo', 'acme.foo', $query);
-        $nestedInnerHit2 = new NestedInnerHit('bar', 'acme.bar', $query);
-        $hit->addInnerHit($nestedInnerHit1);
-        $hit->addInnerHit($nestedInnerHit2);
-
-        $this->assertEquals($nestedInnerHit1, $hit->getInnerHit('foo'));
-        $this->assertEquals($nestedInnerHit2, $hit->getInnerHit('bar'));
-        $this->assertNull($hit->getInnerHit('non_existing_hit'));
+        $this->assertEquals($search, $hit->getQuery());
     }
 }

--- a/tests/InnerHit/ParentInnerHitTest.php
+++ b/tests/InnerHit/ParentInnerHitTest.php
@@ -4,13 +4,18 @@ namespace ONGR\ElasticsearchDSL\Tests\InnerHit;
 
 use ONGR\ElasticsearchDSL\InnerHit\ParentInnerHit;
 use ONGR\ElasticsearchDSL\Query\TermQuery;
+use ONGR\ElasticsearchDSL\Search;
 
 class ParentInnerHitTest extends \PHPUnit_Framework_TestCase
 {
     public function testToArray()
     {
         $query = new TermQuery('foo', 'bar');
-        $hit = new ParentInnerHit('test', 'acme', $query);
+        $search = new Search();
+        $search->addQuery($query);
+
+
+        $hit = new ParentInnerHit('test', 'acme', $search);
         $expected = [
             'type' => [
                 'acme' => [


### PR DESCRIPTION
Hi, 

It's not a full pull request but more a implementation question that need some more work to be completed (tests).
InnerHits support mostly all parameters available for search (from, size, highlight, source, ...)
The current implementation as partial support for this parameters (from some via addParameters).
My proposal is to give a full search to innerhits, It's more user friendly.

In case you agree, you can close this one : https://github.com/ongr-io/ElasticsearchDSL/pull/153 that will be duplicate.

What do you think about it ? 