### PR TITLE
Allow chaining globally

### DIFF
--- a/src/Aggregation/AbstractAggregation.php
+++ b/src/Aggregation/AbstractAggregation.php
@@ -58,10 +58,14 @@ abstract class AbstractAggregation implements BuilderInterface
 
     /**
      * @param string $field
+     *
+     * @return $this
      */
     public function setField($field)
     {
         $this->field = $field;
+
+        return $this;
     }
 
     /**
@@ -86,7 +90,7 @@ abstract class AbstractAggregation implements BuilderInterface
         }
 
         $this->aggregations->add($abstractAggregation);
-        
+
         return $this;
     }
 

--- a/src/Aggregation/CardinalityAggregation.php
+++ b/src/Aggregation/CardinalityAggregation.php
@@ -71,10 +71,14 @@ class CardinalityAggregation extends AbstractAggregation
      * Precision threshold.
      *
      * @param int $precision Precision Threshold.
+     *
+     * @return $this
      */
     public function setPrecisionThreshold($precision)
     {
         $this->precisionThreshold = $precision;
+
+        return $this;
     }
 
     /**
@@ -95,10 +99,14 @@ class CardinalityAggregation extends AbstractAggregation
 
     /**
      * @param bool $rehash
+     *
+     * @return $this
      */
     public function setRehash($rehash)
     {
         $this->rehash = $rehash;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/ChildrenAggregation.php
+++ b/src/Aggregation/ChildrenAggregation.php
@@ -50,10 +50,14 @@ class ChildrenAggregation extends AbstractAggregation
      * Sets children.
      *
      * @param string $children
+     *
+     * @return $this
      */
     public function setChildren($children)
     {
         $this->children = $children;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/DateHistogramAggregation.php
+++ b/src/Aggregation/DateHistogramAggregation.php
@@ -55,10 +55,14 @@ class DateHistogramAggregation extends AbstractAggregation
 
     /**
      * @param string $interval
+     *
+     * @return $this
      */
     public function setInterval($interval)
     {
         $this->interval = $interval;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/DateRangeAggregation.php
+++ b/src/Aggregation/DateRangeAggregation.php
@@ -54,10 +54,14 @@ class DateRangeAggregation extends AbstractAggregation
 
     /**
      * @param string $format
+     *
+     * @return $this
      */
     public function setFormat($format)
     {
         $this->format = $format;
+
+        return $this;
     }
 
     /**
@@ -71,7 +75,7 @@ class DateRangeAggregation extends AbstractAggregation
      * @param string|null $from
      * @param string|null $to
      *
-     * @return RangeAggregation
+     * @return $this
      *
      * @throws \LogicException
      */

--- a/src/Aggregation/ExtendedStatsAggregation.php
+++ b/src/Aggregation/ExtendedStatsAggregation.php
@@ -54,10 +54,14 @@ class ExtendedStatsAggregation extends AbstractAggregation
 
     /**
      * @param int $sigma
+     *
+     * @return $this
      */
     public function setSigma($sigma)
     {
         $this->sigma = $sigma;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/FilterAggregation.php
+++ b/src/Aggregation/FilterAggregation.php
@@ -45,10 +45,14 @@ class FilterAggregation extends AbstractAggregation
      * Sets a filter.
      *
      * @param BuilderInterface $filter
+     *
+     * @return $this
      */
     public function setFilter(BuilderInterface $filter)
     {
         $this->filter = $filter;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/FiltersAggregation.php
+++ b/src/Aggregation/FiltersAggregation.php
@@ -55,7 +55,7 @@ class FiltersAggregation extends AbstractAggregation
     /**
      * @param bool $anonymous
      *
-     * @return FiltersAggregation
+     * @return $this
      */
     public function setAnonymous($anonymous)
     {
@@ -70,7 +70,7 @@ class FiltersAggregation extends AbstractAggregation
      *
      * @throws \LogicException
      *
-     * @return FiltersAggregation
+     * @return $this
      */
     public function addFilter(BuilderInterface $filter, $name = '')
     {

--- a/src/Aggregation/GeoBoundsAggregation.php
+++ b/src/Aggregation/GeoBoundsAggregation.php
@@ -50,10 +50,14 @@ class GeoBoundsAggregation extends AbstractAggregation
 
     /**
      * @param bool $wrapLongitude
+     *
+     * @return $this
      */
     public function setWrapLongitude($wrapLongitude)
     {
         $this->wrapLongitude = $wrapLongitude;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/GeoDistanceAggregation.php
+++ b/src/Aggregation/GeoDistanceAggregation.php
@@ -75,10 +75,14 @@ class GeoDistanceAggregation extends AbstractAggregation
 
     /**
      * @param mixed $origin
+     *
+     * @return $this
      */
     public function setOrigin($origin)
     {
         $this->origin = $origin;
+
+        return $this;
     }
 
     /**
@@ -91,10 +95,14 @@ class GeoDistanceAggregation extends AbstractAggregation
 
     /**
      * @param string $distanceType
+     *
+     * @return $this
      */
     public function setDistanceType($distanceType)
     {
         $this->distanceType = $distanceType;
+
+        return $this;
     }
 
     /**
@@ -107,10 +115,14 @@ class GeoDistanceAggregation extends AbstractAggregation
 
     /**
      * @param string $unit
+     *
+     * @return $this
      */
     public function setUnit($unit)
     {
         $this->unit = $unit;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/GeoHashGridAggregation.php
+++ b/src/Aggregation/GeoHashGridAggregation.php
@@ -64,10 +64,14 @@ class GeoHashGridAggregation extends AbstractAggregation
 
     /**
      * @param int $precision
+     *
+     * @return $this
      */
     public function setPrecision($precision)
     {
         $this->precision = $precision;
+
+        return $this;
     }
 
     /**
@@ -80,10 +84,14 @@ class GeoHashGridAggregation extends AbstractAggregation
 
     /**
      * @param int $size
+     *
+     * @return $this
      */
     public function setSize($size)
     {
         $this->size = $size;
+
+        return $this;
     }
 
     /**
@@ -96,10 +104,14 @@ class GeoHashGridAggregation extends AbstractAggregation
 
     /**
      * @param int $shardSize
+     *
+     * @return $this
      */
     public function setShardSize($shardSize)
     {
         $this->shardSize = $shardSize;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/HistogramAggregation.php
+++ b/src/Aggregation/HistogramAggregation.php
@@ -99,10 +99,14 @@ class HistogramAggregation extends AbstractAggregation
      * Get response as a hash instead keyed by the buckets keys.
      *
      * @param bool $keyed
+     *
+     * @return $this
      */
     public function setKeyed($keyed)
     {
         $this->keyed = $keyed;
+
+        return $this;
     }
 
     /**
@@ -110,11 +114,15 @@ class HistogramAggregation extends AbstractAggregation
      *
      * @param string $mode
      * @param string $direction
+     *
+     * @return $this
      */
     public function setOrder($mode, $direction = self::DIRECTION_ASC)
     {
         $this->orderMode = $mode;
         $this->orderDirection = $direction;
+
+        return $this;
     }
 
     /**
@@ -143,6 +151,8 @@ class HistogramAggregation extends AbstractAggregation
     public function setInterval($interval)
     {
         $this->interval = $interval;
+
+        return $this;
     }
 
     /**
@@ -157,10 +167,14 @@ class HistogramAggregation extends AbstractAggregation
      * Set limit for document count buckets should have.
      *
      * @param int $minDocCount
+     *
+     * @return $this
      */
     public function setMinDocCount($minDocCount)
     {
         $this->minDocCount = $minDocCount;
+
+        return $this;
     }
 
     /**
@@ -174,6 +188,8 @@ class HistogramAggregation extends AbstractAggregation
     /**
      * @param int $min
      * @param int $max
+     *
+     * @return $this
      */
     public function setExtendedBounds($min = null, $max = null)
     {
@@ -184,6 +200,8 @@ class HistogramAggregation extends AbstractAggregation
             ]
         );
         $this->extendedBounds = $bounds;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/NestedAggregation.php
+++ b/src/Aggregation/NestedAggregation.php
@@ -52,10 +52,14 @@ class NestedAggregation extends AbstractAggregation
      * Sets path.
      *
      * @param string $path
+     *
+     * @return $this
      */
     public function setPath($path)
     {
         $this->path = $path;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/PercentileRanksAggregation.php
+++ b/src/Aggregation/PercentileRanksAggregation.php
@@ -61,10 +61,14 @@ class PercentileRanksAggregation extends AbstractAggregation
 
     /**
      * @param array $values
+     *
+     * @return $this
      */
     public function setValues($values)
     {
         $this->values = $values;
+
+        return $this;
     }
 
     /**
@@ -77,10 +81,14 @@ class PercentileRanksAggregation extends AbstractAggregation
 
     /**
      * @param int $compression
+     *
+     * @return $this
      */
     public function setCompression($compression)
     {
         $this->compression = $compression;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/PercentilesAggregation.php
+++ b/src/Aggregation/PercentilesAggregation.php
@@ -61,10 +61,14 @@ class PercentilesAggregation extends AbstractAggregation
 
     /**
      * @param array $percents
+     *
+     * @return $this
      */
     public function setPercents($percents)
     {
         $this->percents = $percents;
+
+        return $this;
     }
 
     /**
@@ -77,10 +81,14 @@ class PercentilesAggregation extends AbstractAggregation
 
     /**
      * @param int $compression
+     *
+     * @return $this
      */
     public function setCompression($compression)
     {
         $this->compression = $compression;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Pipeline/AbstractPipelineAggregation.php
+++ b/src/Aggregation/Pipeline/AbstractPipelineAggregation.php
@@ -34,10 +34,14 @@ abstract class AbstractPipelineAggregation extends AbstractAggregation
 
     /**
      * @param string $bucketsPath
+     *
+     * @return $this
      */
     public function setBucketsPath($bucketsPath)
     {
         $this->bucketsPath = $bucketsPath;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Pipeline/BucketScriptAggregation.php
+++ b/src/Aggregation/Pipeline/BucketScriptAggregation.php
@@ -44,10 +44,14 @@ class BucketScriptAggregation extends AbstractPipelineAggregation
 
     /**
      * @param string $script
+     *
+     * @return $this
      */
     public function setScript($script)
     {
         $this->script = $script;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/ReverseNestedAggregation.php
+++ b/src/Aggregation/ReverseNestedAggregation.php
@@ -52,10 +52,14 @@ class ReverseNestedAggregation extends AbstractAggregation
      * Sets path.
      *
      * @param string $path
+     *
+     * @return $this
      */
     public function setPath($path)
     {
         $this->path = $path;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/SamplerAggregation.php
+++ b/src/Aggregation/SamplerAggregation.php
@@ -56,10 +56,14 @@ class SamplerAggregation extends AbstractAggregation
 
     /**
      * @param int $shardSize
+     *
+     * @return $this
      */
     public function setShardSize($shardSize)
     {
         $this->shardSize = $shardSize;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/TopHitsAggregation.php
+++ b/src/Aggregation/TopHitsAggregation.php
@@ -66,10 +66,14 @@ class TopHitsAggregation extends AbstractAggregation
      * Set from.
      *
      * @param int $from
+     *
+     * @return $this
      */
     public function setFrom($from)
     {
         $this->from = $from;
+
+        return $this;
     }
 
     /**
@@ -86,20 +90,28 @@ class TopHitsAggregation extends AbstractAggregation
      * Set sort.
      *
      * @param BuilderInterface $sort
+     *
+     * @return $this
      */
     public function setSort($sort)
     {
         $this->sort = $sort;
+
+        return $this;
     }
 
     /**
      * Set size.
      *
      * @param int $size
+     *
+     * @return $this
      */
     public function setSize($size)
     {
         $this->size = $size;
+
+        return $this;
     }
 
     /**

--- a/src/NameAwareTrait.php
+++ b/src/NameAwareTrait.php
@@ -28,9 +28,13 @@ trait NameAwareTrait
 
     /**
      * @param mixed $name
+     *
+     * @return $this
      */
     public function setName($name)
     {
         $this->name = $name;
+
+        return $this;
     }
 }

--- a/src/ParametersTrait.php
+++ b/src/ParametersTrait.php
@@ -70,20 +70,28 @@ trait ParametersTrait
     /**
      * @param string                 $name
      * @param array|string|\stdClass $value
+     *
+     * @return $this
      */
     public function addParameter($name, $value)
     {
         $this->parameters[$name] = $value;
+
+        return $this;
     }
 
     /**
      * Sets an array of parameters.
      *
      * @param array $parameters
+     *
+     * @return $this
      */
     public function setParameters(array $parameters)
     {
         $this->parameters = $parameters;
+
+        return $this;
     }
 
     /**

--- a/src/Query/GeoShapeQuery.php
+++ b/src/Query/GeoShapeQuery.php
@@ -51,6 +51,8 @@ class GeoShapeQuery implements BuilderInterface
      * @param string $type        Shape type.
      * @param array  $coordinates Shape coordinates.
      * @param array  $parameters  Additional parameters.
+     *
+     * @return $this
      */
     public function addShape($field, $type, array $coordinates, array $parameters = [])
     {
@@ -63,6 +65,8 @@ class GeoShapeQuery implements BuilderInterface
         );
 
         $this->fields[$field]['shape'] = $filter;
+
+        return $this;
     }
 
     /**
@@ -74,6 +78,8 @@ class GeoShapeQuery implements BuilderInterface
      * @param string $index      Index type where the pre-indexed shape is.
      * @param string $path       The field specified as path containing the pre-indexed shape.
      * @param array  $parameters Additional parameters.
+     *
+     * @return $this
      */
     public function addPreIndexedShape($field, $id, $type, $index, $path, array $parameters = [])
     {
@@ -88,6 +94,8 @@ class GeoShapeQuery implements BuilderInterface
         );
 
         $this->fields[$field]['indexed_shape'] = $filter;
+
+        return $this;
     }
 
     /**

--- a/src/Query/Span/SpanContainingQuery.php
+++ b/src/Query/Span/SpanContainingQuery.php
@@ -52,10 +52,14 @@ class SpanContainingQuery implements SpanQueryInterface
 
     /**
      * @param SpanQueryInterface $little
+     *
+     * @return $this
      */
     public function setLittle(SpanQueryInterface $little)
     {
         $this->little = $little;
+
+        return $this;
     }
 
     /**
@@ -68,10 +72,14 @@ class SpanContainingQuery implements SpanQueryInterface
 
     /**
      * @param SpanQueryInterface $big
+     *
+     * @return $this
      */
     public function setBig(SpanQueryInterface $big)
     {
         $this->big = $big;
+
+        return $this;
     }
 
     /**

--- a/src/Query/Span/SpanNearQuery.php
+++ b/src/Query/Span/SpanNearQuery.php
@@ -33,10 +33,14 @@ class SpanNearQuery extends SpanOrQuery implements SpanQueryInterface
 
     /**
      * @param int $slop
+     *
+     * @return $this
      */
     public function setSlop($slop)
     {
         $this->slop = $slop;
+
+        return $this;
     }
 
     /**

--- a/src/Query/TemplateQuery.php
+++ b/src/Query/TemplateQuery.php
@@ -60,10 +60,14 @@ class TemplateQuery implements BuilderInterface
 
     /**
      * @param string $file
+     *
+     * @return $this
      */
     public function setFile($file)
     {
         $this->file = $file;
+
+        return $this;
     }
 
     /**
@@ -76,10 +80,14 @@ class TemplateQuery implements BuilderInterface
 
     /**
      * @param string $inline
+     *
+     * @return $this
      */
     public function setInline($inline)
     {
         $this->inline = $inline;
+
+        return $this;
     }
 
     /**
@@ -92,10 +100,14 @@ class TemplateQuery implements BuilderInterface
 
     /**
      * @param array $params
+     *
+     * @return $this
      */
     public function setParams($params)
     {
         $this->params = $params;
+
+        return $this;
     }
 
     /**

--- a/src/ScriptAwareTrait.php
+++ b/src/ScriptAwareTrait.php
@@ -31,9 +31,13 @@ trait ScriptAwareTrait
 
     /**
      * @param string $script
+     *
+     * @return $this
      */
     public function setScript($script)
     {
         $this->script = $script;
+
+        return $this;
     }
 }

--- a/src/Search.php
+++ b/src/Search.php
@@ -158,13 +158,17 @@ class Search
      * Sets parameters to the endpoint.
      *
      * @param string $endpointName
-     * @param array  $parameters
+     * @param array $parameters
+     *
+     * @return $this
      */
     private function setEndpointParameters($endpointName, array $parameters)
     {
         /** @var AbstractSearchEndpoint $endpoint */
         $endpoint = $this->getEndpoint($endpointName);
         $endpoint->setParameters($parameters);
+
+        return $this;
     }
 
     /**
@@ -269,7 +273,7 @@ class Search
      *                                   - should.
      * @param string           $key
      *
-     * @return int Key of post filter.
+     * @return $this
      */
     public function addPostFilter(BuilderInterface $filter, $boolType = BoolQuery::MUST, $key = null)
     {
@@ -383,7 +387,7 @@ class Search
      *
      * @param Highlight $highlight
      *
-     * @return int Key of highlight.
+     * @return $this
      */
     public function addHighlight($highlight)
     {

--- a/src/Sort/FieldSort.php
+++ b/src/Sort/FieldSort.php
@@ -61,10 +61,14 @@ class FieldSort implements BuilderInterface
 
     /**
      * @param BuilderInterface $nestedFilter
+     *
+     * @return $this
      */
     public function setNestedFilter(BuilderInterface $nestedFilter)
     {
         $this->nestedFilter = $nestedFilter;
+
+        return $this;
     }
 
     /**

--- a/src/Suggest/Suggest.php
+++ b/src/Suggest/Suggest.php
@@ -13,7 +13,6 @@ namespace ONGR\ElasticsearchDSL\Suggest;
 
 use ONGR\ElasticsearchDSL\BuilderInterface;
 use ONGR\ElasticsearchDSL\ParametersTrait;
-use Symfony\Component\Serializer\Exception\InvalidArgumentException;
 
 class Suggest implements BuilderInterface
 {
@@ -58,10 +57,14 @@ class Suggest implements BuilderInterface
 
     /**
      * @param string $name
+     *
+     * @return $this
      */
     public function setName($name)
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -86,10 +89,14 @@ class Suggest implements BuilderInterface
 
     /**
      * @param string $type
+     *
+     * @return $this
      */
     public function setType($type)
     {
         $this->type = $type;
+
+        return $this;
     }
 
     /**
@@ -102,10 +109,14 @@ class Suggest implements BuilderInterface
 
     /**
      * @param string $text
+     *
+     * @return $this
      */
     public function setText($text)
     {
         $this->text = $text;
+
+        return $this;
     }
 
     /**
@@ -118,10 +129,14 @@ class Suggest implements BuilderInterface
 
     /**
      * @param string $field
+     *
+     * @return $this
      */
     public function setField($field)
     {
         $this->field = $field;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Added on all setter & adder function to be consistent.

I don't touch at these example : 

``` php
class BoolQuery implements BuilderInterface
...
    /**
     * ... 
     * @return string Key of added builder.
     */
    public function add(BuilderInterface $query, $type = self::MUST, $key = null)
```

since this change is BC, but IMO it more useful to allow chaining 
