### PR TITLE
Fix match all query composing

### DIFF
--- a/src/Query/MatchAllQuery.php
+++ b/src/Query/MatchAllQuery.php
@@ -44,6 +44,7 @@ class MatchAllQuery implements BuilderInterface
      */
     public function toArray()
     {
-        return [$this->getType() => $this->getParameters()];
+        $params = $this->getParameters();
+        return [$this->getType() => !empty($params) ? $params : new \stdClass()];
     }
 }

--- a/tests/Query/MatchAllQueryTest.php
+++ b/tests/Query/MatchAllQueryTest.php
@@ -18,9 +18,19 @@ class MatchAllQueryTest extends \PHPUnit_Framework_TestCase
     /**
      * Tests toArray().
      */
-    public function testToArray()
+    public function testToArrayWhenThereAreNoParams()
     {
         $query = new MatchAllQuery();
-        $this->assertEquals(['match_all' => []], $query->toArray());
+        $this->assertEquals(['match_all' => new \stdClass()], $query->toArray());
+    }
+
+    /**
+     * Tests toArray().
+     */
+    public function testToArrayWithParams()
+    {
+        $params = ['boost' => 5];
+        $query = new MatchAllQuery($params);
+        $this->assertEquals(['match_all' => $params], $query->toArray());
     }
 }


### PR DESCRIPTION
When there are no parameters it has to return \stdClass.

Closes #163 

I think it would be nice to fix it in the core `elasticsearch-php` client. 