### PR TITLE
fields was changed to stored_fields in elasticsearch 5.0 #169

### DIFF
--- a/src/Query/FunctionScoreQuery.php
+++ b/src/Query/FunctionScoreQuery.php
@@ -169,7 +169,6 @@ class FunctionScoreQuery implements BuilderInterface
      * Adds script score function.
      *
      * @param string           $script
-     * @param array            $params
      * @param array            $options
      * @param BuilderInterface $query
      *
@@ -177,7 +176,6 @@ class FunctionScoreQuery implements BuilderInterface
      */
     public function addScriptScoreFunction(
         $script,
-        array $params = [],
         array $options = [],
         BuilderInterface $query = null
     ) {
@@ -185,7 +183,6 @@ class FunctionScoreQuery implements BuilderInterface
             'script_score' => array_merge(
                 [
                     'script' => $script,
-                    'params' => $params,
                 ],
                 $options
             ),

--- a/src/Search.php
+++ b/src/Search.php
@@ -68,7 +68,7 @@ class Search
     /**
      * @var array
      */
-    private $fields;
+    private $storedFields;
 
     /**
      * @var array
@@ -556,13 +556,13 @@ class Search
     /**
      * Allows to selectively load specific stored fields for each document represented by a search hit.
      *
-     * @param array $fields
+     * @param array $storedFields
      *
      * @return $this
      */
-    public function setFields(array $fields)
+    public function setStoredFields(array $storedFields)
     {
-        $this->fields = $fields;
+        $this->storedFields = $storedFields;
 
         return $this;
     }
@@ -572,9 +572,9 @@ class Search
      *
      * @return array
      */
-    public function getFields()
+    public function getStoredFields()
     {
-        return $this->fields;
+        return $this->storedFields;
     }
 
     /**
@@ -789,7 +789,7 @@ class Search
         $params = [
             'from' => 'from',
             'size' => 'size',
-            'fields' => 'fields',
+            'storedFields' => 'stored_fields',
             'scriptFields' => 'script_fields',
             'explain' => 'explain',
             'stats' => 'stats',


### PR DESCRIPTION
Hello

I applied the fix for renamed parameter in ES 5.0.

Thanks for this great library!