### PR TITLE
Allow min=0 for extended bounds

### DIFF
--- a/src/Aggregation/Bucketing/HistogramAggregation.php
+++ b/src/Aggregation/Bucketing/HistogramAggregation.php
@@ -184,7 +184,8 @@ class HistogramAggregation extends AbstractAggregation
             [
                 'min' => $min,
                 'max' => $max,
-            ]
+            ],
+            'strlen'
         );
         $this->extendedBounds = $bounds;
     }


### PR DESCRIPTION
At the moment, a 0 value for min extended bounds gets filtered and is not sent in the request.