### PR TITLE
[2.x] FunctionScoreQuery does not reflect Elastic Document

### DIFF
--- a/src/Query/FunctionScoreQuery.php
+++ b/src/Query/FunctionScoreQuery.php
@@ -184,8 +184,11 @@ class FunctionScoreQuery implements BuilderInterface
         $function = [
             'script_score' => array_merge(
                 [
-                    'script' => $script,
-                    'params' => $params,
+                    'script' => [
+                      'lang'   => 'painless',
+                      'inline' => $script,
+                      'params' => $params,
+                    ],
                 ],
                 $options
             ),


### PR DESCRIPTION
Regarding [Document](https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html#function-script-score) on Elastic.co
I think `script_score` has incorrect format