### PR TITLE
Update addScriptScoreFunction to be more complex and work correctly.

### DIFF
--- a/src/Query/FunctionScoreQuery.php
+++ b/src/Query/FunctionScoreQuery.php
@@ -168,27 +168,34 @@ class FunctionScoreQuery implements BuilderInterface
     /**
      * Adds script score function.
      *
-     * @param string           $script
-     * @param array            $params
-     * @param array            $options
+     * @param string $lang
+     * @param string $inline
+     * @param array $params
      * @param BuilderInterface $query
-     *
      * @return $this
      */
     public function addScriptScoreFunction(
-        $script,
-        array $params = [],
-        array $options = [],
+        $lang, 
+        $inline, 
+        array $params = [], 
         BuilderInterface $query = null
-    ) {
+    )
+    {
+        $notIncludeParams = empty($params);
         $function = [
-            'script_score' => array_merge(
-                [
-                    'script' => $script,
-                    'params' => $params,
-                ],
-                $options
-            ),
+            'script_score' => [
+                'script' => $notIncludeParams ?
+                    [
+                        'lang' => $lang,
+                        'inline' => $inline,
+                    ]
+                    :
+                    [
+                        'lang' => $lang,
+                        'inline' => $inline,
+                        'params' => $params,
+                    ]
+            ]
         ];
 
         $this->applyFilter($function, $query);


### PR DESCRIPTION
When I tried to use script_score with `addScriptScoreFunction` got an error:
"script_score query does not support [params]."
So I started digging and there is what i found:

Now code merge "script" and array with params (even if empty). 
```
  "script_score": {
    "script": "_score * doc['my_numeric_field'].value",
    "params": []
  }
````

ES script_score should look like this (via doc.):
https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-function-score-query.html
````
  "script_score": {
    "script": {
      "lang": "painless",
      "inline": "_score * doc['my_numeric_field'].value"
    }
  }
````
or with params:
````
  "script_score": {
    "script": {
      "lang": "painless",
      "params": {
        "param1": value1,
        "param2": value2
      },
      "inline": "_score * doc['my_numeric_field'].value / Math.pow(params.param1, params.param2)"
    }
  }
````
I made a few changes, now it works correctly.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/ongr-io/elasticsearchdsl/188)
<!-- Reviewable:end -->
