### PR TITLE
Ability to add multiple queries in a single call

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -34,7 +34,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "5.0-dev"
+            "dev-master": "5.1-dev"
         }
     }
 }

--- a/src/Search.php
+++ b/src/Search.php
@@ -201,6 +201,28 @@ class Search
 
         return $this;
     }
+    
+    /**
+     * Adds multiple queries to the search.
+     *
+     * @param Array     $query
+     * @param string    $boolType
+     * @param string    $key
+     *
+     * @return $this
+     */
+    public function addQueries(Array $queries)
+    {
+        foreach ($queries as $query) {
+            if (is_array($query)) {
+                $this->addQuery(...$query);    
+            } else {
+                $this->addQuery($query);
+            }
+        }
+
+        return $this;
+    }    
 
     /**
      * Returns endpoint instance.


### PR DESCRIPTION
There are situation where adding multiple queries is super beneficial. 

This PR enables package users to call `$search->addQueries(...)` in two different ways.

#### Single dimension array parameter

In this case an array of `BuilderInterface $query` are passed to the root `$search->addQuery()` function.

#### Multi dimensional array parameter

In this case an array of arrays is passed in, each member of the array is to match the function signature of `$search->addQuery()` and the PHP 5.4 traversable unpacking language feature is used to parameterise the root `$search->addQuery()` function.