### PR TITLE
Adding missing URI parameters

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -663,6 +663,8 @@ class Search
             'lenient',
             'explain',
             '_source',
+            '_source_exclude',
+            '_source_include',
             'stored_fields',
             'sort',
             'track_scores',


### PR DESCRIPTION
'_source_exclude' and '_source_include' was missing in parameters whitelist.