### PR TITLE
Move "elasticsearch/elasticsearch" to dev dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,7 +35,6 @@ Install library with [composer](https://getcomposer.org):
 $ composer require ongr/elasticsearch-dsl
 ```
 
-> [elasticsearch-php](https://github.com/elastic/elasticsearch-php) client is defined in the composer requirements, no need to install it.
 
 ### Search
 
@@ -55,7 +54,7 @@ Create search:
  <?php
   require 'vendor/autoload.php'; //Composer autoload
   
-  $client = ClientBuilder::create()->build(); //elasticsearch-php client
+  $client = ClientBuilder::create()->build(); // elasticsearch-php client
   
   $matchAll = new ONGR\ElasticsearchDSL\Query\MatchAllQuery();
   
@@ -69,5 +68,13 @@ Create search:
   
   $results = $client->search($params);
 ```
+
+> *Note*
+> 
+> In the example above, [the official client](https://github.com/elastic/elasticsearch-php) 
+> for Elasticsearch is used which can be installed by running 
+> ```bash
+> $ composer require elasticsearch/elasticsearch
+> ```
 
 Elasticsearch DSL covers every elasticsearch query, all examples can be found in [the documentation](docs/index.md)

--- a/composer.json
+++ b/composer.json
@@ -13,13 +13,13 @@
     "require": {
         "php": ">=5.6",
         "symfony/serializer": "~2.7|~3.0",
-        "paragonie/random_compat": "^2.0",
-        "elasticsearch/elasticsearch": "~5.0"
+        "paragonie/random_compat": "^2.0"
     },
     "require-dev": {
         "phpunit/phpunit": "~5.6",
         "squizlabs/php_codesniffer": "~2.0",
-        "satooshi/php-coveralls": "~1.0"
+        "satooshi/php-coveralls": "~1.0",
+        "elasticsearch/elasticsearch": "~5.0"
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
Correct me if I'm wrong, but the only usage of `elasticsearch/elasticsearch` I found is in the `tests\Functional` directory. So there is no need to force users to install unused dependency by default.