### PR TITLE
Add support for symfony serializer component v4

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,7 +8,7 @@ php:
 env:
   global:
     - JAVA_HOME="/usr/lib/jvm/java-8-oracle/jre"
-    - ELASRICSEARCH_HOST="127.0.0.1:9200"
+    - ELASTICSEARCH_HOST="127.0.0.1:9200"
     - ES_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.2.zip"
 matrix:
   allow_failures:

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,7 +7,7 @@ php:
   - hhvm
 env:
   global:
-    - JAVA_HOME="/usr/lib/jvm/java-8-oracle/jre"
+    - JAVA_HOME="/usr/lib/jvm/java-9-oracle/jre"
     - ELASTICSEARCH_HOST="127.0.0.1:9200"
     - ES_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.2.zip"
 matrix:
@@ -15,7 +15,7 @@ matrix:
     - php: hhvm
 install:
   # Container based PHP image ues PHP 5.6.5, once it will be upgraded sudo will be not necessary
-  - sudo apt-get install -y oracle-java8-set-default
+  - sudo apt-get install -y oracle-java9-set-default
   - curl -L -o elasticsearch.zip $ES_URL
   - unzip elasticsearch.zip
   - ./elasticsearch-*/bin/elasticsearch -d -Escript.inline=true -Escript.stored=true

--- a/composer.json
+++ b/composer.json
@@ -11,8 +11,8 @@
         }
     ],
     "require": {
-        "php": ">=5.6",
-        "symfony/serializer": "~2.7|~3.0",
+        "php": "^5.6 || ^7.0",
+        "symfony/serializer": "~2.7 || ~3.0 || ~4.0",
         "paragonie/random_compat": "^2.0",
         "elasticsearch/elasticsearch": "~5.0"
     },

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^5.6 || ^7.0",
-        "symfony/serializer": "~2.7 || ~3.0 || ~4.0",
+        "symfony/serializer": "~2.7|~3.0|~4.0",
         "paragonie/random_compat": "^2.0",
         "elasticsearch/elasticsearch": "~5.0"
     },


### PR DESCRIPTION
* Fixed typo ELASTICSEARCH_HOST in .travis.yml
* Used Java9 as Java8 broke the travis build
* Added symfony serializer component v4

#SymfonyConHackday2017