### PR TITLE
Add Symfony 4 compatibillity

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,7 @@ env:
     - PREFER_LOWEST="--prefer-lowest --prefer-stable"
     - PREFER_LOWEST=""
   global:
-    - JAVA_HOME="/usr/lib/jvm/java-8-oracle/jre"
+    - JAVA_HOME="/usr/lib/jvm/java-9-oracle/jre"
     - ELASRICSEARCH_HOST="127.0.0.1:9200"
     - ES_URL="https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-5.1.2.zip"
 matrix:
@@ -19,7 +19,7 @@ matrix:
     - php: hhvm
 install:
   # Container based PHP image ues PHP 5.6.5, once it will be upgraded sudo will be not necessary
-  - sudo apt-get install -y oracle-java8-set-default
+  - sudo apt-get install -y oracle-java9-set-default
   - curl -L -o elasticsearch.zip $ES_URL
   - unzip elasticsearch.zip
   - ./elasticsearch-*/bin/elasticsearch -d -Escript.inline=true -Escript.stored=true

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,11 @@ php:
   - 7.0
   - 7.1
   - hhvm
+
 env:
+  matrix:
+    - PREFER_LOWEST="--prefer-lowest --prefer-stable"
+    - PREFER_LOWEST=""
   global:
     - JAVA_HOME="/usr/lib/jvm/java-8-oracle/jre"
     - ELASRICSEARCH_HOST="127.0.0.1:9200"
@@ -21,7 +25,7 @@ install:
   - ./elasticsearch-*/bin/elasticsearch -d -Escript.inline=true -Escript.stored=true
 before_script:
   - composer config -g github-oauth.github.com $GITHUB_COMPOSER_AUTH
-  - composer install --no-interaction --prefer-dist
+  - composer update --no-interaction --prefer-source $PREFER_LOWEST
 script:
   - vendor/bin/phpunit --coverage-clover=coverage.clover
   - vendor/bin/phpcs -p --standard=PSR2 --ignore=vendor/ ./

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": ">=5.6",
-        "symfony/serializer": "~2.7|~3.0",
+        "symfony/serializer": "~2.7|~3.0|~4.0",
         "paragonie/random_compat": "^2.0",
         "elasticsearch/elasticsearch": "~5.0"
     },


### PR DESCRIPTION
Fixes https://github.com/ongr-io/ElasticsearchDSL/issues/248.

- Adds symfony/serializer 4.0 compatibillity
- Adds travis runs with lowest dependencies to build matrix, see https://evertpot.com/testing-composer-prefer-lowest/

Edit:
Apparently this duplicates https://github.com/ongr-io/ElasticsearchDSL/pull/243 

