### PR TITLE
fixes #255 - added null check to array_filter 

### DIFF
--- a/src/Aggregation/Bucketing/DateRangeAggregation.php
+++ b/src/Aggregation/Bucketing/DateRangeAggregation.php
@@ -86,7 +86,10 @@ class DateRangeAggregation extends AbstractAggregation
                 'from' => $from,
                 'to' => $to,
                 'key' => $key,
-            ]
+            ],
+            function ($v) {
+                return !is_null($v);
+            }
         );
 
         if (empty($range)) {

--- a/src/Aggregation/Bucketing/GeoDistanceAggregation.php
+++ b/src/Aggregation/Bucketing/GeoDistanceAggregation.php
@@ -132,7 +132,10 @@ class GeoDistanceAggregation extends AbstractAggregation
             [
                 'from' => $from,
                 'to' => $to,
-            ]
+            ],
+            function ($v) {
+                return !is_null($v);
+            }
         );
 
         if (empty($range)) {

--- a/src/Aggregation/Bucketing/Ipv4RangeAggregation.php
+++ b/src/Aggregation/Bucketing/Ipv4RangeAggregation.php
@@ -65,7 +65,10 @@ class Ipv4RangeAggregation extends AbstractAggregation
             [
                 'from' => $from,
                 'to' => $to,
-            ]
+            ],
+            function ($v) {
+                return !is_null($v);
+            }
         );
 
         $this->ranges[] = $range;

--- a/src/Aggregation/Bucketing/RangeAggregation.php
+++ b/src/Aggregation/Bucketing/RangeAggregation.php
@@ -84,7 +84,10 @@ class RangeAggregation extends AbstractAggregation
             [
                 'from' => $from,
                 'to' => $to,
-            ]
+            ],
+            function ($v) {
+                return !is_null($v);
+            }
         );
 
         if ($this->keyed && !empty($key)) {


### PR DESCRIPTION
fixes #255 - added null check to array_filter to allow `0` values to pass through

Example `['from' => 0, 'to' => 0]` is a valid aggregate range