### PR TITLE
added new NestedSort for replacing deprecated nested_filter and nested_path

### DIFF
--- a/src/Sort/FieldSort.php
+++ b/src/Sort/FieldSort.php
@@ -87,7 +87,7 @@ class FieldSort implements BuilderInterface
         }
 
         if ($this->nestedFilter) {
-            $this->addParameter('nested_filter', $this->nestedFilter->toArray());
+            $this->addParameter('nested', $this->nestedFilter->toArray());
         }
 
         $output = [

--- a/src/Sort/NestedSort.php
+++ b/src/Sort/NestedSort.php
@@ -45,7 +45,7 @@ class NestedSort implements BuilderInterface
      */
     public function __construct(
         $path,
-        BuilderInterface $filter,
+        BuilderInterface $filter = null,
         array $parameters = []
     ) {
         $this->path = $path;
@@ -68,8 +68,11 @@ class NestedSort implements BuilderInterface
     {
         $output = [
             'path'   => $this->path,
-            'filter' => $this->filter->toArray(),
         ];
+
+        if ($this->filter) {
+            $output['filter'] = $this->filter->toArray();
+        }
 
         if ($this->nestedFilter) {
             $output[$this->getType()] = $this->nestedFilter->toArray();

--- a/src/Sort/NestedSort.php
+++ b/src/Sort/NestedSort.php
@@ -1,0 +1,116 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Sort;
+
+use ONGR\ElasticsearchDSL\BuilderInterface;
+use ONGR\ElasticsearchDSL\ParametersTrait;
+
+/**
+ * Represents Elasticsearch "nested" sort filter.
+ *
+ * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/filter-dsl-nested-filter.html
+ */
+class NestedSort implements BuilderInterface
+{
+    use ParametersTrait;
+
+    /**
+     * @var string
+     */
+    private $path;
+
+    /**
+     * @var BuilderInterface
+     */
+    private $filter;
+
+    /**
+     * @var BuilderInterface
+     */
+    private $nestedFilter;
+
+    /**
+     * @param string $path
+     * @param BuilderInterface $filter
+     * @param array $parameters
+     */
+    public function __construct(
+        $path,
+        BuilderInterface $filter,
+        array $parameters = []
+    ) {
+        $this->path = $path;
+        $this->filter = $filter;
+        $this->setParameters($parameters);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getType()
+    {
+        return 'nested';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function toArray()
+    {
+        $output = [
+            'path'   => $this->path,
+            'filter' => $this->filter->toArray(),
+        ];
+
+        if ($this->nestedFilter) {
+            $output[$this->getType()] = $this->nestedFilter->toArray();
+        }
+
+        return $this->processArray($output);
+    }
+
+    /**
+     * Returns nested filter object.
+     *
+     * @return BuilderInterface
+     */
+    public function getFilter()
+    {
+        return $this->filter;
+    }
+
+    /**
+     * Returns path this filter is set for.
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * @return BuilderInterface
+     */
+    public function getNestedFilter()
+    {
+        return $this->nestedFilter;
+    }
+
+    /**
+     * @param BuilderInterface $nestedFilter
+     */
+    public function setNestedFilter(BuilderInterface $nestedFilter)
+    {
+        $this->nestedFilter = $nestedFilter;
+    }
+}

--- a/tests/Unit/Sort/FieldSortTest.php
+++ b/tests/Unit/Sort/FieldSortTest.php
@@ -1,0 +1,46 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Tests\Unit\Sort;
+
+use ONGR\ElasticsearchDSL\Query\TermLevel\TermQuery;
+use ONGR\ElasticsearchDSL\Sort\FieldSort;
+use ONGR\ElasticsearchDSL\Sort\NestedSort;
+
+class FieldSortTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test for toArray() method.
+     *
+     */
+    public function testToArray()
+    {
+        $nestedFilter = new NestedSort('somePath', new TermQuery('somePath.id', 10));
+        $sort = new FieldSort('someField', 'asc');
+        $sort->setNestedFilter($nestedFilter);
+
+        $expected = [
+            'someField' => [
+                'nested' => [
+                    'path'   => 'somePath',
+                    'filter' => [
+                        'term' => [
+                            'somePath.id' => 10,
+                        ]
+                    ]
+                ],
+                'order'  => 'asc'
+            ],
+        ];
+        $result = $sort->toArray();
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/Unit/Sort/NestedSortTest.php
+++ b/tests/Unit/Sort/NestedSortTest.php
@@ -1,0 +1,76 @@
+<?php
+
+/*
+ * This file is part of the ONGR package.
+ *
+ * (c) NFQ Technologies UAB <info@nfq.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace ONGR\ElasticsearchDSL\Tests\Unit\Sort;
+
+use ONGR\ElasticsearchDSL\Query\TermLevel\TermQuery;
+use ONGR\ElasticsearchDSL\Sort\NestedSort;
+
+class NestedSortTest extends \PHPUnit\Framework\TestCase
+{
+    /**
+     * Test for single nested.
+     *
+     */
+    public function testSingle()
+    {
+        $query = new NestedSort('somePath', new TermQuery('somePath.id', 10));
+        $expected = [
+            'path'   => 'somePath',
+            'filter' => [
+                'term' => [
+                    'somePath.id' => 10,
+                ]
+            ]
+        ];
+        $result = $query->toArray();
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
+     * Test for single nested.
+     *
+     */
+    public function testMultipleNesting()
+    {
+        $query = new NestedSort('somePath', new TermQuery('somePath.id', 10));
+        $nestedFilter1 = new NestedSort('secondPath', new TermQuery('secondPath.foo', 'bar'));
+        $nestedFilter2 = new NestedSort('thirdPath', new TermQuery('thirdPath.x', 'y'));
+        $nestedFilter1->setNestedFilter($nestedFilter2);
+        $query->setNestedFilter($nestedFilter1);
+        $expected = [
+            'path'   => 'somePath',
+            'filter' => [
+                'term' => [
+                    'somePath.id' => 10,
+                ]
+            ],
+            'nested' => [
+                'path'   => 'secondPath',
+                'filter' => [
+                    'term' => [
+                        'secondPath.foo' => 'bar',
+                    ]
+                ],
+                'nested' => [
+                    'path'   => 'thirdPath',
+                    'filter' => [
+                        'term' => [
+                            'thirdPath.x' => 'y',
+                        ]
+                    ],
+                ]
+            ]
+        ];
+        $result = $query->toArray();
+        $this->assertEquals($expected, $result);
+    }
+}

--- a/tests/Unit/Sort/NestedSortTest.php
+++ b/tests/Unit/Sort/NestedSortTest.php
@@ -36,6 +36,20 @@ class NestedSortTest extends \PHPUnit\Framework\TestCase
     }
 
     /**
+     * Test for single nested, no filter.
+     *
+     */
+    public function testNoFilter()
+    {
+        $query = new NestedSort('somePath');
+        $expected = [
+            'path'   => 'somePath',
+        ];
+        $result = $query->toArray();
+        $this->assertEquals($expected, $result);
+    }
+
+    /**
      * Test for single nested.
      *
      */


### PR DESCRIPTION
Includes unit tests
fixes https://github.com/ongr-io/ElasticsearchDSL/issues/266

Note that this is only working in 6.1. You probably need a separate branch for 6.0 if you want this 6.1 feature.

Sample usage:
```php
$sort = new FieldSort('someField', 'asc');
$nestedFilter = new NestedSort('somePath', new TermQuery('somePath.id', 10));
$sort->setNestedFilter($nestedFilter);
var_dump($sort->toArray());
```

Nested filter can be nested by calling `setNestedFilter` on a `NestedSort`