### PR TITLE
Serializer in search should be static

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -155,7 +155,7 @@ class Search
     /**
      * @var OrderedSerializer
      */
-    private $serializer;
+    private static $serializer;
 
     /**
      * @var SearchEndpointInterface[]
@@ -167,12 +167,14 @@ class Search
      */
     public function __construct()
     {
-        $this->serializer = new OrderedSerializer(
-            [
-                new CustomReferencedNormalizer(),
-                new CustomNormalizer(),
-            ]
-        );
+        if (static::$serializer === null) {
+            static::$serializer = new OrderedSerializer(
+                [
+                    new CustomReferencedNormalizer(),
+                    new CustomNormalizer(),
+                ]
+            );
+        }
     }
 
     /**
@@ -698,7 +700,7 @@ class Search
      */
     public function toArray()
     {
-        $output = array_filter($this->serializer->normalize($this->endpoints));
+        $output = array_filter(static::$serializer->normalize($this->endpoints));
 
         $params = [
             'from' => 'from',


### PR DESCRIPTION
With the current implementation, new Serializer will be created for every instance of Search class. Depending on the amount of created instances, this may add noticeable overhead.

Now the Serializer instance will be created once and reused from that on.