### PR TITLE
In RangeAggregation, remove keyed option condition for to have range key

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,5 +1,5 @@
 {
-    "name": "ongr/elasticsearch-dsl",
+    "name": "gbourgeat/elasticsearch-dsl",
     "description": "Elasticsearch DSL library",
     "type": "library",
     "homepage": "http://ongr.io",

--- a/src/Aggregation/Bucketing/RangeAggregation.php
+++ b/src/Aggregation/Bucketing/RangeAggregation.php
@@ -90,7 +90,7 @@ class RangeAggregation extends AbstractAggregation
             }
         );
 
-        if ($this->keyed && !empty($key)) {
+        if (!empty($key)) {
             $range['key'] = $key;
         }
 


### PR DESCRIPTION
In RangeAggregation, remove keyed option condition for to have range key in result