### PR TITLE
Add getQuery Method to FunctionScoreQuery

### DIFF
--- a/src/Query/Compound/FunctionScoreQuery.php
+++ b/src/Query/Compound/FunctionScoreQuery.php
@@ -41,17 +41,17 @@ class FunctionScoreQuery implements BuilderInterface
     {
         $this->query = $query;
         $this->setParameters($parameters);
-    }
-    
+    }    
+
     /**
      * Returns the query instance.
      *
-     * @return BuilderInterface object 
+     * @return BuilderInterface object
      */
     public function getQuery()
     {
         return $this->query;
-    }    
+    }
 
     /**
      * Creates field_value_factor function.

--- a/src/Query/Compound/FunctionScoreQuery.php
+++ b/src/Query/Compound/FunctionScoreQuery.php
@@ -42,6 +42,16 @@ class FunctionScoreQuery implements BuilderInterface
         $this->query = $query;
         $this->setParameters($parameters);
     }
+    
+    /**
+     * Returns the query instance.
+     *
+     * @return BuilderInterface object 
+     */
+    public function getQuery()
+    {
+        return $this->query;
+    }    
 
     /**
      * Creates field_value_factor function.


### PR DESCRIPTION
A getQuery Method added to FunctionScoreQuery.php.
Developers can use the method in order to apply some changes to query of FunctionScoreQuery.
