### PR TITLE
fix get bool doctype to get available typehints

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -223,7 +223,7 @@ class Search
     /**
      * Returns queries inside BoolQuery instance.
      *
-     * @return BuilderInterface
+     * @return BoolQuery
      */
     public function getQueries()
     {
@@ -283,7 +283,7 @@ class Search
     /**
      * Returns queries inside BoolFilter instance.
      *
-     * @return BuilderInterface
+     * @return BoolQuery
      */
     public function getPostFilters()
     {

--- a/src/SearchEndpoint/SearchEndpointInterface.php
+++ b/src/SearchEndpoint/SearchEndpointInterface.php
@@ -12,6 +12,7 @@
 namespace ONGR\ElasticsearchDSL\SearchEndpoint;
 
 use ONGR\ElasticsearchDSL\BuilderInterface;
+use ONGR\ElasticsearchDSL\Query\Compound\BoolQuery;
 use Symfony\Component\Serializer\Normalizer\NormalizableInterface;
 
 /**
@@ -71,7 +72,7 @@ interface SearchEndpointInterface extends NormalizableInterface
     /**
      * Returns Bool filter or query instance with all builder objects inside.
      *
-     * @return BuilderInterface
+     * @return BoolQuery
      */
     public function getBool();
 }


### PR DESCRIPTION
To get the available hits, it has to return the exact class. Also, the class shouldn't change.