### PR TITLE
Allow more scalar values in TermQuery

### DIFF
--- a/src/Query/TermLevel/TermQuery.php
+++ b/src/Query/TermLevel/TermQuery.php
@@ -34,9 +34,9 @@ class TermQuery implements BuilderInterface
     private $value;
 
     /**
-     * @param string $field
-     * @param string $value
-     * @param array  $parameters
+     * @param string                $field
+     * @param string|int|float|bool $value
+     * @param array                 $parameters
      */
     public function __construct($field, $value, array $parameters = [])
     {


### PR DESCRIPTION
Since Elasticsearch supports more than just strings, I think it would be a good addition to allow those values in the constructor of `TermQuery` to reflect this.

We're currently trying to improve the depth of the static code analysis of our project. While doing so, this issue showed up. We are using the `TermQuery` with bool or integer values, which shouldn't be possible according to the current typehints.