### PR TITLE
Update to allow multi-match query with no fields

### DIFF
--- a/src/Query/FullText/MultiMatchQuery.php
+++ b/src/Query/FullText/MultiMatchQuery.php
@@ -18,6 +18,12 @@ use ONGR\ElasticsearchDSL\ParametersTrait;
  * Represents Elasticsearch "multi_match" query.
  *
  * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/query-dsl-multi-match-query.html
+ *
+ * Allows `$fields` to be an empty array to represent 'no fields'. From the Elasticsearch documentation:
+ *
+ * If no fields are provided, the multi_match query defaults to the `index.query.default_field` index settings,
+ * which in turn defaults to `*`. `*` extracts all fields in the mapping that are eligible to term queries and filters
+ * the metadata fields. All extracted fields are then combined to build a query.
  */
 class MultiMatchQuery implements BuilderInterface
 {
@@ -59,9 +65,11 @@ class MultiMatchQuery implements BuilderInterface
     public function toArray()
     {
         $query = [
-            'fields' => $this->fields,
             'query' => $this->query,
         ];
+        if (count($this->fields)) {
+            $query['fields'] = $this->fields;
+        }
 
         $output = $this->processArray($query);
 

--- a/tests/Unit/Query/FullText/MultiMatchQueryTest.php
+++ b/tests/Unit/Query/FullText/MultiMatchQueryTest.php
@@ -30,4 +30,19 @@ class MultiMatchQueryTest extends \PHPUnit\Framework\TestCase
 
         $this->assertEquals($expected, $query->toArray());
     }
+
+    /**
+     * Tests multi-match query with no fields.
+     */
+    public function testToArrayWithNoFields()
+    {
+        $query = new MultiMatchQuery([], 'this is a test');
+        $expected = [
+            'multi_match' => [
+                'query' => 'this is a test',
+            ],
+        ];
+
+        $this->assertEquals($expected, $query->toArray());
+    }
 }


### PR DESCRIPTION
From the Elasticsearch documentation:

> If no fields are provided, the multi_match query defaults to the `index.query.default_field` index settings, which in turn defaults to `*`. `*` extracts all fields in the mapping that are eligible to term
queries and filters the metadata fields. All extracted fields are then combined to build a query.