### PR TITLE
[6.x] Consistent chainable mutator behavior

### DIFF
--- a/src/Aggregation/AbstractAggregation.php
+++ b/src/Aggregation/AbstractAggregation.php
@@ -58,10 +58,14 @@ abstract class AbstractAggregation implements NamedBuilderInterface
 
     /**
      * @param string $field
+     *
+     * @return $this
      */
     public function setField($field)
     {
         $this->field = $field;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Bucketing/ChildrenAggregation.php
+++ b/src/Aggregation/Bucketing/ChildrenAggregation.php
@@ -50,13 +50,15 @@ class ChildrenAggregation extends AbstractAggregation
     }
 
     /**
-     * Sets children.
-     *
      * @param string $children
+     *
+     * @return $this
      */
     public function setChildren($children)
     {
         $this->children = $children;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Bucketing/CompositeAggregation.php
+++ b/src/Aggregation/Bucketing/CompositeAggregation.php
@@ -103,11 +103,13 @@ class CompositeAggregation extends AbstractAggregation
      *
      * @param int $size Size
      *
-     * @return void
+     * @return $this
      */
     public function setSize($size)
     {
         $this->size = $size;
+
+        return $this;
     }
 
     /**
@@ -125,11 +127,13 @@ class CompositeAggregation extends AbstractAggregation
      *
      * @param array $after After
      *
-     * @return void
+     * @return $this
      */
     public function setAfter(array $after)
     {
         $this->after = $after;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Bucketing/DateHistogramAggregation.php
+++ b/src/Aggregation/Bucketing/DateHistogramAggregation.php
@@ -59,18 +59,26 @@ class DateHistogramAggregation extends AbstractAggregation
 
     /**
      * @param string $interval
+     *
+     * @return $this
      */
     public function setInterval($interval)
     {
         $this->interval = $interval;
+
+        return $this;
     }
 
     /**
      * @param string $format
+     *
+     * @return $this
      */
     public function setFormat($format)
     {
         $this->format = $format;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Bucketing/DateRangeAggregation.php
+++ b/src/Aggregation/Bucketing/DateRangeAggregation.php
@@ -58,10 +58,14 @@ class DateRangeAggregation extends AbstractAggregation
 
     /**
      * @param string $format
+     *
+     * @return $this
      */
     public function setFormat($format)
     {
         $this->format = $format;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Bucketing/DiversifiedSamplerAggregation.php
+++ b/src/Aggregation/Bucketing/DiversifiedSamplerAggregation.php
@@ -54,10 +54,14 @@ class DiversifiedSamplerAggregation extends AbstractAggregation
 
     /**
      * @param mixed $shardSize
+     *
+     * @return $this
      */
     public function setShardSize($shardSize)
     {
         $this->shardSize = $shardSize;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Bucketing/FilterAggregation.php
+++ b/src/Aggregation/Bucketing/FilterAggregation.php
@@ -45,13 +45,15 @@ class FilterAggregation extends AbstractAggregation
     }
 
     /**
-     * Sets a filter.
-     *
      * @param BuilderInterface $filter
+     *
+     * @return $this
      */
     public function setFilter(BuilderInterface $filter)
     {
         $this->filter = $filter;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Bucketing/FiltersAggregation.php
+++ b/src/Aggregation/Bucketing/FiltersAggregation.php
@@ -58,7 +58,7 @@ class FiltersAggregation extends AbstractAggregation
     /**
      * @param bool $anonymous
      *
-     * @return FiltersAggregation
+     * @return $this
      */
     public function setAnonymous($anonymous)
     {

--- a/src/Aggregation/Bucketing/GeoDistanceAggregation.php
+++ b/src/Aggregation/Bucketing/GeoDistanceAggregation.php
@@ -78,10 +78,14 @@ class GeoDistanceAggregation extends AbstractAggregation
 
     /**
      * @param mixed $origin
+     *
+     * @return $this
      */
     public function setOrigin($origin)
     {
         $this->origin = $origin;
+
+        return $this;
     }
 
     /**
@@ -94,10 +98,14 @@ class GeoDistanceAggregation extends AbstractAggregation
 
     /**
      * @param string $distanceType
+     *
+     * @return $this
      */
     public function setDistanceType($distanceType)
     {
         $this->distanceType = $distanceType;
+
+        return $this;
     }
 
     /**
@@ -110,10 +118,14 @@ class GeoDistanceAggregation extends AbstractAggregation
 
     /**
      * @param string $unit
+     *
+     * @return $this
      */
     public function setUnit($unit)
     {
         $this->unit = $unit;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Bucketing/GeoHashGridAggregation.php
+++ b/src/Aggregation/Bucketing/GeoHashGridAggregation.php
@@ -67,10 +67,14 @@ class GeoHashGridAggregation extends AbstractAggregation
 
     /**
      * @param int $precision
+     *
+     * @return $this
      */
     public function setPrecision($precision)
     {
         $this->precision = $precision;
+
+        return $this;
     }
 
     /**
@@ -83,10 +87,14 @@ class GeoHashGridAggregation extends AbstractAggregation
 
     /**
      * @param int $size
+     *
+     * @return $this
      */
     public function setSize($size)
     {
         $this->size = $size;
+
+        return $this;
     }
 
     /**
@@ -99,10 +107,14 @@ class GeoHashGridAggregation extends AbstractAggregation
 
     /**
      * @param int $shardSize
+     *
+     * @return $this
      */
     public function setShardSize($shardSize)
     {
         $this->shardSize = $shardSize;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Bucketing/HistogramAggregation.php
+++ b/src/Aggregation/Bucketing/HistogramAggregation.php
@@ -102,10 +102,14 @@ class HistogramAggregation extends AbstractAggregation
      * Get response as a hash instead keyed by the buckets keys.
      *
      * @param bool $keyed
+     *
+     * @return $this
      */
     public function setKeyed($keyed)
     {
         $this->keyed = $keyed;
+
+        return $this;
     }
 
     /**
@@ -113,11 +117,15 @@ class HistogramAggregation extends AbstractAggregation
      *
      * @param string $mode
      * @param string $direction
+     *
+     * @return $this
      */
     public function setOrder($mode, $direction = self::DIRECTION_ASC)
     {
         $this->orderMode = $mode;
         $this->orderDirection = $direction;
+
+        return $this;
     }
 
     /**
@@ -142,10 +150,14 @@ class HistogramAggregation extends AbstractAggregation
 
     /**
      * @param int $interval
+     *
+     * @return $this
      */
     public function setInterval($interval)
     {
         $this->interval = $interval;
+
+        return $this;
     }
 
     /**
@@ -160,10 +172,14 @@ class HistogramAggregation extends AbstractAggregation
      * Set limit for document count buckets should have.
      *
      * @param int $minDocCount
+     *
+     * @return $this
      */
     public function setMinDocCount($minDocCount)
     {
         $this->minDocCount = $minDocCount;
+
+        return $this;
     }
 
     /**
@@ -177,6 +193,8 @@ class HistogramAggregation extends AbstractAggregation
     /**
      * @param int $min
      * @param int $max
+     *
+     * @return $this
      */
     public function setExtendedBounds($min = null, $max = null)
     {
@@ -188,6 +206,8 @@ class HistogramAggregation extends AbstractAggregation
             'strlen'
         );
         $this->extendedBounds = $bounds;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Bucketing/NestedAggregation.php
+++ b/src/Aggregation/Bucketing/NestedAggregation.php
@@ -52,13 +52,15 @@ class NestedAggregation extends AbstractAggregation
     }
 
     /**
-     * Sets path.
-     *
      * @param string $path
+     *
+     * @return $this
      */
     public function setPath($path)
     {
         $this->path = $path;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Bucketing/RangeAggregation.php
+++ b/src/Aggregation/Bucketing/RangeAggregation.php
@@ -60,7 +60,7 @@ class RangeAggregation extends AbstractAggregation
      *
      * @param bool $keyed
      *
-     * @return RangeAggregation
+     * @return $this
      */
     public function setKeyed($keyed)
     {

--- a/src/Aggregation/Bucketing/ReverseNestedAggregation.php
+++ b/src/Aggregation/Bucketing/ReverseNestedAggregation.php
@@ -52,13 +52,15 @@ class ReverseNestedAggregation extends AbstractAggregation
     }
 
     /**
-     * Sets path.
-     *
      * @param string $path
+     *
+     * @return $this
      */
     public function setPath($path)
     {
         $this->path = $path;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Bucketing/SamplerAggregation.php
+++ b/src/Aggregation/Bucketing/SamplerAggregation.php
@@ -54,10 +54,14 @@ class SamplerAggregation extends AbstractAggregation
 
     /**
      * @param int $shardSize
+     *
+     * @return $this
      */
     public function setShardSize($shardSize)
     {
         $this->shardSize = $shardSize;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Matrix/MatrixStatsAggregation.php
+++ b/src/Aggregation/Matrix/MatrixStatsAggregation.php
@@ -60,10 +60,14 @@ class MaxAggregation extends AbstractAggregation
 
     /**
      * @param string $mode
+     *
+     * @return $this
      */
     public function setMode($mode)
     {
         $this->mode = $mode;
+
+        return $this;
     }
 
     /**
@@ -76,10 +80,14 @@ class MaxAggregation extends AbstractAggregation
 
     /**
      * @param array $missing
+     *
+     * @return $this
      */
     public function setMissing($missing)
     {
         $this->missing = $missing;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Metric/CardinalityAggregation.php
+++ b/src/Aggregation/Metric/CardinalityAggregation.php
@@ -58,13 +58,15 @@ class CardinalityAggregation extends AbstractAggregation
     }
 
     /**
-     * Precision threshold.
+     * @param int $precision
      *
-     * @param int $precision Precision Threshold.
+     * @return $this
      */
     public function setPrecisionThreshold($precision)
     {
         $this->precisionThreshold = $precision;
+
+        return $this;
     }
 
     /**
@@ -85,10 +87,14 @@ class CardinalityAggregation extends AbstractAggregation
 
     /**
      * @param bool $rehash
+     *
+     * @return $this
      */
     public function setRehash($rehash)
     {
         $this->rehash = $rehash;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Metric/ExtendedStatsAggregation.php
+++ b/src/Aggregation/Metric/ExtendedStatsAggregation.php
@@ -57,10 +57,14 @@ class ExtendedStatsAggregation extends AbstractAggregation
 
     /**
      * @param int $sigma
+     *
+     * @return $this
      */
     public function setSigma($sigma)
     {
         $this->sigma = $sigma;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Metric/GeoBoundsAggregation.php
+++ b/src/Aggregation/Metric/GeoBoundsAggregation.php
@@ -53,10 +53,14 @@ class GeoBoundsAggregation extends AbstractAggregation
 
     /**
      * @param bool $wrapLongitude
+     *
+     * @return $this
      */
     public function setWrapLongitude($wrapLongitude)
     {
         $this->wrapLongitude = $wrapLongitude;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Metric/PercentileRanksAggregation.php
+++ b/src/Aggregation/Metric/PercentileRanksAggregation.php
@@ -64,10 +64,14 @@ class PercentileRanksAggregation extends AbstractAggregation
 
     /**
      * @param array $values
+     *
+     * @return $this
      */
     public function setValues($values)
     {
         $this->values = $values;
+
+        return $this;
     }
 
     /**
@@ -80,10 +84,14 @@ class PercentileRanksAggregation extends AbstractAggregation
 
     /**
      * @param int $compression
+     *
+     * @return $this
      */
     public function setCompression($compression)
     {
         $this->compression = $compression;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Metric/PercentilesAggregation.php
+++ b/src/Aggregation/Metric/PercentilesAggregation.php
@@ -64,10 +64,14 @@ class PercentilesAggregation extends AbstractAggregation
 
     /**
      * @param array $percents
+     *
+     * @return $this
      */
     public function setPercents($percents)
     {
         $this->percents = $percents;
+
+        return $this;
     }
 
     /**
@@ -80,10 +84,14 @@ class PercentilesAggregation extends AbstractAggregation
 
     /**
      * @param int $compression
+     *
+     * @return $this
      */
     public function setCompression($compression)
     {
         $this->compression = $compression;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Metric/ScriptedMetricAggregation.php
+++ b/src/Aggregation/Metric/ScriptedMetricAggregation.php
@@ -85,10 +85,14 @@ class ScriptedMetricAggregation extends AbstractAggregation
 
     /**
      * @param mixed $initScript
+     *
+     * @return $this
      */
     public function setInitScript($initScript)
     {
         $this->initScript = $initScript;
+
+        return $this;
     }
 
     /**
@@ -101,10 +105,14 @@ class ScriptedMetricAggregation extends AbstractAggregation
 
     /**
      * @param mixed $mapScript
+     *
+     * @return $this
      */
     public function setMapScript($mapScript)
     {
         $this->mapScript = $mapScript;
+
+        return $this;
     }
 
     /**
@@ -117,10 +125,14 @@ class ScriptedMetricAggregation extends AbstractAggregation
 
     /**
      * @param mixed $combineScript
+     *
+     * @return $this
      */
     public function setCombineScript($combineScript)
     {
         $this->combineScript = $combineScript;
+
+        return $this;
     }
 
     /**
@@ -133,10 +145,14 @@ class ScriptedMetricAggregation extends AbstractAggregation
 
     /**
      * @param mixed $reduceScript
+     *
+     * @return $this
      */
     public function setReduceScript($reduceScript)
     {
         $this->reduceScript = $reduceScript;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Metric/TopHitsAggregation.php
+++ b/src/Aggregation/Metric/TopHitsAggregation.php
@@ -66,13 +66,15 @@ class TopHitsAggregation extends AbstractAggregation
     }
 
     /**
-     * Set from.
-     *
      * @param int $from
+     *
+     * @return $this
      */
     public function setFrom($from)
     {
         $this->from = $from;
+
+        return $this;
     }
 
     /**
@@ -85,10 +87,14 @@ class TopHitsAggregation extends AbstractAggregation
 
     /**
      * @param BuilderInterface[] $sorts
+     *
+     * @return $this
      */
     public function setSorts(array $sorts)
     {
         $this->sorts = $sorts;
+
+        return $this;
     }
 
     /**
@@ -102,13 +108,15 @@ class TopHitsAggregation extends AbstractAggregation
     }
 
     /**
-     * Set size.
-     *
      * @param int $size
+     *
+     * @return $this
      */
     public function setSize($size)
     {
         $this->size = $size;
+
+        return $this;
     }
 
     /**
@@ -176,12 +184,14 @@ class TopHitsAggregation extends AbstractAggregation
     /**
      * @deprecated sorts now is a container, use `addSort()`instead.
      *
-     * Set sort.
-     *
      * @param BuilderInterface $sort
+     *
+     * @return $this
      */
     public function setSort(BuilderInterface $sort)
     {
         $this->sort = $sort;
+
+        return $this;
     }
 }

--- a/src/Aggregation/Pipeline/AbstractPipelineAggregation.php
+++ b/src/Aggregation/Pipeline/AbstractPipelineAggregation.php
@@ -34,10 +34,14 @@ abstract class AbstractPipelineAggregation extends AbstractAggregation
 
     /**
      * @param string $bucketsPath
+     *
+     * @return $this
      */
     public function setBucketsPath($bucketsPath)
     {
         $this->bucketsPath = $bucketsPath;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Pipeline/BucketScriptAggregation.php
+++ b/src/Aggregation/Pipeline/BucketScriptAggregation.php
@@ -44,10 +44,14 @@ class BucketScriptAggregation extends AbstractPipelineAggregation
 
     /**
      * @param string $script
+     *
+     * @return $this
      */
     public function setScript($script)
     {
         $this->script = $script;
+
+        return $this;
     }
 
     /**

--- a/src/Aggregation/Pipeline/BucketSortAggregation.php
+++ b/src/Aggregation/Pipeline/BucketSortAggregation.php
@@ -53,11 +53,13 @@ class BucketSortAggregation extends AbstractPipelineAggregation
 
     /**
      * @param string $sort
-     * @return self
+     *
+     * @return $this
      */
     public function setSort($sort)
     {
         $this->sort = $sort;
+
         return $this;
     }
 

--- a/src/Aggregation/Pipeline/PercentilesBucketAggregation.php
+++ b/src/Aggregation/Pipeline/PercentilesBucketAggregation.php
@@ -41,10 +41,14 @@ class PercentilesBucketAggregation extends AbstractPipelineAggregation
 
     /**
      * @param array $percents
+     *
+     * @return $this
      */
     public function setPercents(array $percents)
     {
         $this->percents = $percents;
+
+        return $this;
     }
 
     /**

--- a/src/FieldAwareTrait.php
+++ b/src/FieldAwareTrait.php
@@ -27,10 +27,14 @@ trait FieldAwareTrait
     }
 
     /**
-     * @param mixed $field
+     * @param string $field
+     *
+     * @return $this
      */
     public function setField($field)
     {
         $this->field = $field;
+
+        return $this;
     }
 }

--- a/src/NameAwareTrait.php
+++ b/src/NameAwareTrait.php
@@ -27,10 +27,14 @@ trait NameAwareTrait
     }
 
     /**
-     * @param mixed $name
+     * @param string $name
+     *
+     * @return $this
      */
     public function setName($name)
     {
         $this->name = $name;
+
+        return $this;
     }
 }

--- a/src/ParametersTrait.php
+++ b/src/ParametersTrait.php
@@ -77,13 +77,15 @@ trait ParametersTrait
     }
 
     /**
-     * Sets an array of parameters.
-     *
      * @param array $parameters
+     *
+     * @return $this
      */
     public function setParameters(array $parameters)
     {
         $this->parameters = $parameters;
+
+        return $this;
     }
 
     /**

--- a/src/Query/Span/FieldMaskingSpanQuery.php
+++ b/src/Query/Span/FieldMaskingSpanQuery.php
@@ -52,11 +52,13 @@ class FieldMaskingSpanQuery implements SpanQueryInterface
 
     /**
      * @param mixed $query
-     * @return self
+     *
+     * @return $this
      */
     public function setQuery($query)
     {
         $this->query = $query;
+
         return $this;
     }
 
@@ -70,11 +72,13 @@ class FieldMaskingSpanQuery implements SpanQueryInterface
 
     /**
      * @param string $field
-     * @return FieldMaskingSpanQuery
+     *
+     * @return $this
      */
     public function setField($field)
     {
         $this->field = $field;
+
         return $this;
     }
 

--- a/src/Query/Span/SpanContainingQuery.php
+++ b/src/Query/Span/SpanContainingQuery.php
@@ -52,10 +52,14 @@ class SpanContainingQuery implements SpanQueryInterface
 
     /**
      * @param SpanQueryInterface $little
+     *
+     * @return $this
      */
     public function setLittle(SpanQueryInterface $little)
     {
         $this->little = $little;
+
+        return $this;
     }
 
     /**
@@ -68,10 +72,14 @@ class SpanContainingQuery implements SpanQueryInterface
 
     /**
      * @param SpanQueryInterface $big
+     *
+     * @return $this
      */
     public function setBig(SpanQueryInterface $big)
     {
         $this->big = $big;
+
+        return $this;
     }
 
     /**

--- a/src/Query/Span/SpanNearQuery.php
+++ b/src/Query/Span/SpanNearQuery.php
@@ -33,10 +33,14 @@ class SpanNearQuery extends SpanOrQuery implements SpanQueryInterface
 
     /**
      * @param int $slop
+     *
+     * @return $this
      */
     public function setSlop($slop)
     {
         $this->slop = $slop;
+
+        return $this;
     }
 
     /**

--- a/src/Query/Specialized/TemplateQuery.php
+++ b/src/Query/Specialized/TemplateQuery.php
@@ -60,10 +60,14 @@ class TemplateQuery implements BuilderInterface
 
     /**
      * @param string $file
+     *
+     * @return $this;
      */
     public function setFile($file)
     {
         $this->file = $file;
+
+        return $this;
     }
 
     /**
@@ -76,10 +80,14 @@ class TemplateQuery implements BuilderInterface
 
     /**
      * @param string $inline
+     *
+     * @return $this
      */
     public function setInline($inline)
     {
         $this->inline = $inline;
+
+        return $this;
     }
 
     /**
@@ -92,10 +100,14 @@ class TemplateQuery implements BuilderInterface
 
     /**
      * @param array $params
+     *
+     * @return $this
      */
     public function setParams($params)
     {
         $this->params = $params;
+
+        return $this;
     }
 
     /**

--- a/src/ScriptAwareTrait.php
+++ b/src/ScriptAwareTrait.php
@@ -31,9 +31,13 @@ trait ScriptAwareTrait
 
     /**
      * @param string $script
+     *
+     * @return $this
      */
     public function setScript($script)
     {
         $this->script = $script;
+
+        return $this;
     }
 }

--- a/src/Search.php
+++ b/src/Search.php
@@ -259,12 +259,16 @@ class Search
      *
      * @param string $endpointName
      * @param array  $parameters
+     *
+     * @return $this
      */
     public function setEndpointParameters($endpointName, array $parameters)
     {
         /** @var AbstractSearchEndpoint $endpoint */
         $endpoint = $this->getEndpoint($endpointName);
         $endpoint->setParameters($parameters);
+
+        return $this;
     }
 
     /**
@@ -447,11 +451,13 @@ class Search
 
     /**
      * @param int $from
+     *
      * @return $this
      */
     public function setFrom($from)
     {
         $this->from = $from;
+
         return $this;
     }
 
@@ -465,11 +471,13 @@ class Search
 
     /**
      * @param bool $trackTotalHits
+     *
      * @return $this
      */
     public function setTrackTotalHits(bool $trackTotalHits)
     {
         $this->trackTotalHits = $trackTotalHits;
+
         return $this;
     }
 
@@ -483,11 +491,13 @@ class Search
 
     /**
      * @param int $size
+     *
      * @return $this
      */
     public function setSize($size)
     {
         $this->size = $size;
+
         return $this;
     }
 
@@ -501,11 +511,13 @@ class Search
 
     /**
      * @param bool $source
+     *
      * @return $this
      */
     public function setSource($source)
     {
         $this->source = $source;
+
         return $this;
     }
 
@@ -519,11 +531,13 @@ class Search
 
     /**
      * @param array $storedFields
+     *
      * @return $this
      */
     public function setStoredFields($storedFields)
     {
         $this->storedFields = $storedFields;
+
         return $this;
     }
 
@@ -537,11 +551,13 @@ class Search
 
     /**
      * @param array $scriptFields
+     *
      * @return $this
      */
     public function setScriptFields($scriptFields)
     {
         $this->scriptFields = $scriptFields;
+
         return $this;
     }
 
@@ -555,11 +571,13 @@ class Search
 
     /**
      * @param array $docValueFields
+     *
      * @return $this
      */
     public function setDocValueFields($docValueFields)
     {
         $this->docValueFields = $docValueFields;
+
         return $this;
     }
 
@@ -573,11 +591,13 @@ class Search
 
     /**
      * @param bool $explain
+     *
      * @return $this
      */
     public function setExplain($explain)
     {
         $this->explain = $explain;
+
         return $this;
     }
 
@@ -591,11 +611,13 @@ class Search
 
     /**
      * @param bool $version
+     *
      * @return $this
      */
     public function setVersion($version)
     {
         $this->version = $version;
+
         return $this;
     }
 
@@ -609,11 +631,13 @@ class Search
 
     /**
      * @param array $indicesBoost
+     *
      * @return $this
      */
     public function setIndicesBoost($indicesBoost)
     {
         $this->indicesBoost = $indicesBoost;
+
         return $this;
     }
 
@@ -627,11 +651,13 @@ class Search
 
     /**
      * @param int $minScore
+     *
      * @return $this
      */
     public function setMinScore($minScore)
     {
         $this->minScore = $minScore;
+
         return $this;
     }
 
@@ -645,11 +671,13 @@ class Search
 
     /**
      * @param array $searchAfter
+     *
      * @return $this
      */
     public function setSearchAfter($searchAfter)
     {
         $this->searchAfter = $searchAfter;
+
         return $this;
     }
 
@@ -663,6 +691,7 @@ class Search
 
     /**
      * @param string $scroll
+     *
      * @return $this
      */
     public function setScroll($scroll = '5m')

--- a/src/Sort/FieldSort.php
+++ b/src/Sort/FieldSort.php
@@ -61,11 +61,13 @@ class FieldSort implements BuilderInterface
 
     /**
      * @param string $field
-     * @return self
+     *
+     * @return $this
      */
     public function setField($field)
     {
         $this->field = $field;
+
         return $this;
     }
 
@@ -79,11 +81,13 @@ class FieldSort implements BuilderInterface
 
     /**
      * @param string $order
-     * @return self
+     *
+     * @return $this
      */
     public function setOrder($order)
     {
         $this->order = $order;
+
         return $this;
     }
 
@@ -97,10 +101,14 @@ class FieldSort implements BuilderInterface
 
     /**
      * @param BuilderInterface $nestedFilter
+     *
+     * @return $this
      */
     public function setNestedFilter(BuilderInterface $nestedFilter)
     {
         $this->nestedFilter = $nestedFilter;
+
+        return $this;
     }
 
     /**

--- a/src/Sort/NestedSort.php
+++ b/src/Sort/NestedSort.php
@@ -111,9 +111,13 @@ class NestedSort implements BuilderInterface
 
     /**
      * @param BuilderInterface $nestedFilter
+     *
+     * @return $this
      */
     public function setNestedFilter(BuilderInterface $nestedFilter)
     {
         $this->nestedFilter = $nestedFilter;
+
+        return $this;
     }
 }

--- a/src/Suggest/Suggest.php
+++ b/src/Suggest/Suggest.php
@@ -58,10 +58,14 @@ class Suggest implements NamedBuilderInterface
 
     /**
      * @param string $name
+     *
+     * @return $this
      */
     public function setName($name)
     {
         $this->name = $name;
+
+        return $this;
     }
 
     /**
@@ -86,10 +90,14 @@ class Suggest implements NamedBuilderInterface
 
     /**
      * @param string $type
+     *
+     * @return $this
      */
     public function setType($type)
     {
         $this->type = $type;
+
+        return $this;
     }
 
     /**
@@ -102,10 +110,14 @@ class Suggest implements NamedBuilderInterface
 
     /**
      * @param string $text
+     *
+     * @return $this
      */
     public function setText($text)
     {
         $this->text = $text;
+
+        return $this;
     }
 
     /**
@@ -118,10 +130,14 @@ class Suggest implements NamedBuilderInterface
 
     /**
      * @param string $field
+     *
+     * @return $this
      */
     public function setField($field)
     {
         $this->field = $field;
+
+        return $this;
     }
 
     /**


### PR DESCRIPTION
Self-explanatory, all setters should be consistent and return $this.

Common usage is as follows:

```php
(new Search)
    ->addAggregation((new CardinalityAggregation('count'))->setField('abc')) 
...