### PR TITLE
Fluent api on ParametersTrait

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,9 @@ php:
   - 7.2
   - 7.3
   - 7.4snapshot
-  matrix:
-    allow_failures:
-        - php: 7.4snapshot
+matrix:
+  allow_failures:
+      - php: 7.4snapshot
 env:
   global:
     - ES_VERSION=7.4.0 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,7 +6,7 @@ php:
   - 7.3
 env:
   global:
-    - ES_VERSION=7.4.0 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+    - ES_VERSION=7.4.0 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz
 install:
   - wget ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,6 +4,10 @@ php:
   - 7.1
   - 7.2
   - 7.3
+  - 7.4snapshot
+  matrix:
+    allow_failures:
+        - php: 7.4snapshot
 env:
   global:
     - ES_VERSION=7.4.0 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,12 +1,12 @@
 sudo: false
 language: php
 php:
-  - 7.0
   - 7.1
   - 7.2
+  - 7.3
 env:
   global:
-    - ES_VERSION=6.7.1 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
+    - ES_VERSION=7.4.0 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}.tar.gz
 install:
   - wget ${ES_DOWNLOAD_URL}
   - tar -xzf elasticsearch-${ES_VERSION}.tar.gz

--- a/.travis.yml
+++ b/.travis.yml
@@ -9,7 +9,7 @@ env:
     - ES_VERSION=7.4.0 ES_DOWNLOAD_URL=https://artifacts.elastic.co/downloads/elasticsearch/elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz
 install:
   - wget ${ES_DOWNLOAD_URL}
-  - tar -xzf elasticsearch-${ES_VERSION}.tar.gz
+  - tar -xzf elasticsearch-${ES_VERSION}-linux-x86_64.tar.gz
   - ./elasticsearch-${ES_VERSION}/bin/elasticsearch -d
 before_script:
   - if [ "$GITHUB_COMPOSER_AUTH" ]; then composer config -g github-oauth.github.com $GITHUB_COMPOSER_AUTH; fi

--- a/README.md
+++ b/README.md
@@ -11,6 +11,11 @@ is the preffered and recommended way to ask ONGR support questions.
 [![Total Downloads](https://poser.pugx.org/ongr/elasticsearch-dsl/downloads)](https://packagist.org/packages/ongr/elasticsearch-dsl)
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/ongr-io/ElasticsearchDSL/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/ongr-io/ElasticsearchDSL/?branch=master)
 
+
+If you like this library help me to develop it by buying a cup of coffee
+
+<a href="https://www.buymeacoffee.com/zIKBXRc" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
+
 ## Version matrix
 
 | Elasticsearch version | ElasticsearchDSL version    |

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 Introducing Elasticsearch DSL library to provide objective query builder for [Elasticsearch bundle](https://github.com/ongr-io/ElasticsearchBundle) and [elasticsearch-php](https://github.com/elastic/elasticsearch-php) client. You can easily build any Elasticsearch query and transform it to an array.
 
 If you need any help, [stack overflow](http://stackoverflow.com/questions/tagged/ongr)
-is the preffered and recommended way to ask ONGR support questions.
+is the preferred and recommended way to ask ONGR support questions.
  
 [![Build Status](https://travis-ci.org/ongr-io/ElasticsearchDSL.svg?branch=master)](https://travis-ci.org/ongr-io/ElasticsearchDSL)
 [![codecov](https://codecov.io/gh/ongr-io/ElasticsearchDSL/branch/master/graph/badge.svg)](https://codecov.io/gh/ongr-io/ElasticsearchDSL)
@@ -12,7 +12,7 @@ is the preffered and recommended way to ask ONGR support questions.
 [![Scrutinizer Code Quality](https://scrutinizer-ci.com/g/ongr-io/ElasticsearchDSL/badges/quality-score.png?b=master)](https://scrutinizer-ci.com/g/ongr-io/ElasticsearchDSL/?branch=master)
 
 
-If you like this library help me to develop it by buying a cup of coffee
+If you like this library, help me to develop it by buying a cup of coffee
 
 <a href="https://www.buymeacoffee.com/zIKBXRc" target="_blank"><img src="https://www.buymeacoffee.com/assets/img/custom_images/orange_img.png" alt="Buy Me A Coffee" style="height: 41px !important;width: 174px !important;box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;-webkit-box-shadow: 0px 3px 2px 0px rgba(190, 190, 190, 0.5) !important;" ></a>
 

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.1",
         "symfony/serializer": "^3.0|^4.0",
         "paragonie/random_compat": "*"
     },

--- a/composer.json
+++ b/composer.json
@@ -16,7 +16,7 @@
         "paragonie/random_compat": "*"
     },
     "require-dev": {
-        "elasticsearch/elasticsearch": "^6.0",
+        "elasticsearch/elasticsearch": "^7.0",
         "phpunit/phpunit": "~6.0",
         "squizlabs/php_codesniffer": "^3.0",
         "php-coveralls/php-coveralls": "^2.1"
@@ -37,7 +37,7 @@
     "minimum-stability": "dev",
     "extra": {
         "branch-alias": {
-            "dev-master": "6.1-dev"
+            "dev-master": "7.0-dev"
         }
     }
 }

--- a/src/ParametersTrait.php
+++ b/src/ParametersTrait.php
@@ -37,12 +37,15 @@ trait ParametersTrait
      * Removes parameter.
      *
      * @param string $name
+     * @return $this
      */
     public function removeParameter($name)
     {
         if ($this->hasParameter($name)) {
             unset($this->parameters[$name]);
         }
+
+        return $this;
     }
 
     /**
@@ -70,10 +73,13 @@ trait ParametersTrait
     /**
      * @param string                 $name
      * @param array|string|int|bool|\stdClass $value
+     * @return $this
      */
     public function addParameter($name, $value)
     {
         $this->parameters[$name] = $value;
+
+        return $this;
     }
 
     /**

--- a/tests/Unit/ParametersTraitTest.php
+++ b/tests/Unit/ParametersTraitTest.php
@@ -37,10 +37,10 @@ class ParametersTraitTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetAndAddParameter()
     {
-        $parent = $this->parametersTraitMock->addParameter('acme', 123);
-        $this->assertTrue(is_object($parent));
+        $this->assertTrue(is_object($this->parametersTraitMock->addParameter('acme', 123)));
         $this->assertEquals(123, $this->parametersTraitMock->getParameter('acme'));
         $this->parametersTraitMock->addParameter('bar', 321);
         $this->assertEquals(321, $this->parametersTraitMock->getParameter('bar'));
+        $this->assertTrue(is_object($this->parametersTraitMock->removeParameter('acme')));
     }
 }

--- a/tests/Unit/ParametersTraitTest.php
+++ b/tests/Unit/ParametersTraitTest.php
@@ -11,6 +11,7 @@
 
 namespace ONGR\ElasticsearchDSL\Tests\Unit;
 
+use ONGR\ElasticsearchDSL\Aggregation\AbstractAggregation;
 use ONGR\ElasticsearchDSL\ParametersTrait;
 
 /**
@@ -36,7 +37,8 @@ class ParametersTraitTest extends \PHPUnit\Framework\TestCase
      */
     public function testGetAndAddParameter()
     {
-        $this->parametersTraitMock->addParameter('acme', 123);
+        $parent = $this->parametersTraitMock->addParameter('acme', 123);
+        $this->assertTrue(is_object($parent));
         $this->assertEquals(123, $this->parametersTraitMock->getParameter('acme'));
         $this->parametersTraitMock->addParameter('bar', 321);
         $this->assertEquals(321, $this->parametersTraitMock->getParameter('bar'));


### PR DESCRIPTION
I added the ability to chain method when using `removeParameter` and `addParameter` in ParametersTrait returning `$this`.

Fluent api is yet available in `setParameters` method, but if you need to apply parameters by multiple call on `addParameter` you can't get advantage by methods chain.