### PR TITLE
Add float as parameters hint for static analysis

### DIFF
--- a/src/ParametersTrait.php
+++ b/src/ParametersTrait.php
@@ -50,7 +50,7 @@ trait ParametersTrait
      *
      * @param string $name
      *
-     * @return array|string|int|bool|\stdClass
+     * @return array|string|int|float|bool|\stdClass
      */
     public function getParameter($name)
     {
@@ -69,7 +69,7 @@ trait ParametersTrait
 
     /**
      * @param string                 $name
-     * @param array|string|int|bool|\stdClass $value
+     * @param array|string|int|float|bool|\stdClass $value
      */
     public function addParameter($name, $value)
     {


### PR DESCRIPTION
Parameters like "boost" are floats (default Value is 1.0). So a static analysis could show errors here.