### PR TITLE
Fixed Interface Issues with Type Hinting

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
     ],
     "require": {
         "php": "^7.0",
-        "symfony/serializer": "^3.0|^4.0",
+        "symfony/serializer": "^3.0|^4.0|^5.0",
         "paragonie/random_compat": "*"
     },
     "require-dev": {

--- a/src/Serializer/Normalizer/CustomReferencedNormalizer.php
+++ b/src/Serializer/Normalizer/CustomReferencedNormalizer.php
@@ -38,7 +38,7 @@ class CustomReferencedNormalizer extends CustomNormalizer
     /**
      * {@inheritdoc}
      */
-    public function supportsNormalization($data, $format = null)
+    public function supportsNormalization($data, string $format = null)
     {
         return $data instanceof AbstractNormalizable;
     }

--- a/src/Serializer/OrderedSerializer.php
+++ b/src/Serializer/OrderedSerializer.php
@@ -22,7 +22,7 @@ class OrderedSerializer extends Serializer
     /**
      * {@inheritdoc}
      */
-    public function normalize($data, $format = null, array $context = [])
+    public function normalize($data, string $format = null, array $context = [])
     {
         return parent::normalize(
             is_array($data) ? $this->order($data) : $data,
@@ -34,7 +34,7 @@ class OrderedSerializer extends Serializer
     /**
      * {@inheritdoc}
      */
-    public function denormalize($data, $type, $format = null, array $context = [])
+    public function denormalize($data, string $type, string $format = null, array $context = [])
     {
         return parent::denormalize(
             is_array($data) ? $this->order($data) : $data,


### PR DESCRIPTION
Issues arose in Laravel Project. 
Symfony\Component\Serializer\Normalizer\NormalizerInterface::normalize($object, ?string $format = NULL, array $context = Array)
Symfony\Component\Serializer\Normalizer\DenormalizerInterface::denormalize($data, string $type, ?string $format = NULL, array $context = Array)
Symfony\Component\Serializer\Normalizer\DenormalizerInterface::denormalize($data, string $type, ?string $format = NULL, array $context = Array)

Resolved by type hinting string in the affected files.