### PR TITLE
Add rest_total_hits_as_int to allowed Uri Params

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -752,6 +752,7 @@ class Search
             'typed_keys',
             'pre_filter_shard_size',
             'ignore_unavailable',
+            'rest_total_hits_as_int',
         ])) {
             $this->uriParams[$name] = $value;
         } else {


### PR DESCRIPTION
This allow to get in ES7 again to total as int instead of an object.