### PR TITLE
BucketScriptAggregation bucketsPath param

### DIFF
--- a/src/Aggregation/Pipeline/AbstractPipelineAggregation.php
+++ b/src/Aggregation/Pipeline/AbstractPipelineAggregation.php
@@ -25,7 +25,7 @@ abstract class AbstractPipelineAggregation extends AbstractAggregation
     }
 
     /**
-     * @return string
+     * @return array|string
      */
     public function getBucketsPath()
     {
@@ -33,7 +33,7 @@ abstract class AbstractPipelineAggregation extends AbstractAggregation
     }
 
     /**
-     * @param string $bucketsPath
+     * @param array|string $bucketsPath
      *
      * @return $this
      */


### PR DESCRIPTION
Since `BucketScriptAggregation` constructor accepts `array` type of `$bucketsPath` parameter, the parent class should also accept arrays in its setter (`setBucketsPath`).