### PR TITLE
Allow more types for `_source` field

### DIFF
--- a/src/Search.php
+++ b/src/Search.php
@@ -63,7 +63,7 @@ class Search
      * operations return the contents of the _source field unless you have used the
      * stored_fields parameter or if the _source field is disabled.
      *
-     * @var bool
+     * @var bool|string|array
      */
     private $source;
 
@@ -522,11 +522,19 @@ class Search
      */
     public function isSource()
     {
+        return $this->source !== false && $this->source !== '';
+    }
+
+    /**
+     * @return bool|string|array
+     */
+    public function getSource()
+    {
         return $this->source;
     }
 
     /**
-     * @param bool $source
+     * @param bool|string|array $source
      *
      * @return $this
      */


### PR DESCRIPTION
The `_source` field can be `false` or a string/array that contains the fields that should be returned.

See: https://www.elastic.co/guide/en/elasticsearch/reference/6.8/search-request-source-filtering.html