### PR TITLE
Cleanup `composer.json`

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -13,15 +13,11 @@
     "require": {
         "php": "^7.2",
         "symfony/serializer": "^5.0",
-        "paragonie/random_compat": "*",
         "elasticsearch/elasticsearch": "^7.0"
     },
     "require-dev": {
         "phpunit/phpunit": "^7.0",
         "squizlabs/php_codesniffer": "^3.0"
-    },
-    "suggest": {
-      "elasticsearch/elasticsearch": "This library is for elasticsearch/elasticsearch client to enhance it with DSL functionality."
     },
     "autoload": {
         "psr-4": {


### PR DESCRIPTION
- `paragonie/random_compat` is not needed as it is a polyfill for PHP < 7
- `suggest: elasticsearch/elasticsearch` is not needed because it's already required