### PR TITLE
Adds shape type constants to GeoShapeQuery

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,7 +20,7 @@ before_script:
   - composer install --no-interaction --prefer-dist
 script:
   - wget -q --waitretry=1 --retry-connrefused -T 10 -O - http://127.0.0.1:9200
-  - vendor/bin/phpunit --coverage-clover=coverage.xml
+  - XDEBUG_MODE=coverage vendor/bin/phpunit --coverage-clover=coverage.xml
   - vendor/bin/phpcs -p --standard=PSR2 --ignore=vendor/ ./
 after_script:
   - travis_retry bash <(curl -s https://codecov.io/bash)

--- a/src/Query/Geo/GeoShapeQuery.php
+++ b/src/Query/Geo/GeoShapeQuery.php
@@ -28,6 +28,21 @@ class GeoShapeQuery implements BuilderInterface
     const WITHIN = 'within';
     const CONTAINS = 'contains';
 
+    /*
+     * Available shape types for addShape() $type param.
+     *
+     * @link https://www.elastic.co/guide/en/elasticsearch/reference/current/geo-shape.html#input-structure
+     */
+    const SHAPE_TYPE_POINT = 'point';
+    const SHAPE_TYPE_LINESTRING = 'linestring';
+    const SHAPE_TYPE_POLYGON = 'polygon';
+    const SHAPE_TYPE_MULTIPOINT = 'multipoint';
+    const SHAPE_TYPE_MULTILINESTRING = 'multilinestring';
+    const SHAPE_TYPE_MULTIPOLYGON = 'multipolygon';
+    const SHAPE_TYPE_GEOMETRYCOLLECTION = 'geometrycollection';
+    const SHAPE_TYPE_ENVELOPE = 'envelope';
+    const SHAPE_TYPE_CIRCLE = 'circle';
+
     /**
      * @var array
      */

--- a/tests/Unit/Query/Geo/GeoShapeQueryTest.php
+++ b/tests/Unit/Query/Geo/GeoShapeQueryTest.php
@@ -21,7 +21,12 @@ class GeoShapeQueryTest extends \PHPUnit\Framework\TestCase
     public function testToArray()
     {
         $filter = new GeoShapeQuery(['param1' => 'value1']);
-        $filter->addShape('location', 'envelope', [[13, 53], [14, 52]], GeoShapeQuery::INTERSECTS);
+        $filter->addShape(
+            'location',
+            GeoShapeQuery::SHAPE_TYPE_ENVELOPE,
+            [[13, 53], [14, 52]],
+            GeoShapeQuery::INTERSECTS
+        );
 
         $expected = [
             'geo_shape' => [


### PR DESCRIPTION
* Enumerates available options for the shape type parameter
* Includes unit test update demonstrating use of the `GeoShapeQuery::SHAPE_TYPE_ENVELOPE` constant

Also includes fix to enable Xdebug 3 support in phpunit