### PR TITLE
Fixed for PHP 8 Compatibility

### DIFF
--- a/.github/workflows/phpunit.yml
+++ b/.github/workflows/phpunit.yml
@@ -16,7 +16,7 @@ jobs:
           discovery.type: single-node
     strategy:
       matrix:
-        php: ['7.3', '7.4']
+        php: ['7.4', '8.0']
     steps:
     - uses: actions/checkout@v2
   

--- a/composer.json
+++ b/composer.json
@@ -11,7 +11,7 @@
         }
     ],
     "require": {
-        "php": "^7.3",
+        "php": "^7.4 || ^8.0",
         "symfony/serializer": "^5.0",
         "elasticsearch/elasticsearch": "^7.0"
     },

--- a/src/Serializer/OrderedSerializer.php
+++ b/src/Serializer/OrderedSerializer.php
@@ -59,7 +59,7 @@ class OrderedSerializer extends Serializer
             uasort(
                 $filteredData,
                 function (OrderedNormalizerInterface $a, OrderedNormalizerInterface $b) {
-                    return $a->getOrder() > $b->getOrder();
+                    return $a->getOrder() <=> $b->getOrder();
                 }
             );
 

--- a/tests/Unit/Aggregation/Bucketing/AdjacencyMatrixAggregationTest.php
+++ b/tests/Unit/Aggregation/Bucketing/AdjacencyMatrixAggregationTest.php
@@ -60,7 +60,7 @@ class AdjacencyMatrixAggregationTest extends \PHPUnit\Framework\TestCase
     {
         $aggregation = new AdjacencyMatrixAggregation('test_agg');
         $filter = $this->getMockBuilder('ONGR\ElasticsearchDSL\BuilderInterface')
-            ->setMethods(['toArray', 'getType'])
+            ->onlyMethods(['toArray', 'getType'])
             ->getMockForAbstractClass();
         $filter->expects($this->any())
             ->method('toArray')

--- a/tests/Unit/Aggregation/Bucketing/DateRangeAggregationTest.php
+++ b/tests/Unit/Aggregation/Bucketing/DateRangeAggregationTest.php
@@ -115,7 +115,7 @@ class DateRangeAggregationTest extends \PHPUnit\Framework\TestCase
     public function testDateRangeAggregationConstructor($field = null, $format = null, array $ranges = null)
     {
         $aggregation = $this->getMockBuilder('ONGR\ElasticsearchDSL\Aggregation\Bucketing\DateRangeAggregation')
-            ->setMethods(['setField', 'setFormat', 'addRange'])
+            ->onlyMethods(['setField', 'setFormat', 'addRange'])
             ->disableOriginalConstructor()
             ->getMock();
         $aggregation->expects($this->once())->method('setField')->with($field);

--- a/tests/Unit/Aggregation/Bucketing/FiltersAggregationTest.php
+++ b/tests/Unit/Aggregation/Bucketing/FiltersAggregationTest.php
@@ -60,7 +60,7 @@ class FiltersAggregationTest extends \PHPUnit\Framework\TestCase
     {
         $aggregation = new FiltersAggregation('test_agg');
         $filter = $this->getMockBuilder('ONGR\ElasticsearchDSL\BuilderInterface')
-            ->setMethods(['toArray', 'getType'])
+            ->onlyMethods(['toArray', 'getType'])
             ->getMockForAbstractClass();
         $filter->expects($this->any())
             ->method('toArray')

--- a/tests/Unit/BuilderBagTest.php
+++ b/tests/Unit/BuilderBagTest.php
@@ -85,7 +85,8 @@ class BuilderBagTest extends \PHPUnit\Framework\TestCase
     private function getBuilder($name)
     {
         $friendlyBuilderMock = $this->getMockBuilder('ONGR\ElasticsearchDSL\BuilderInterface')
-            ->setMethods(['getName', 'toArray', 'getType'])
+            ->onlyMethods(['toArray', 'getType'])
+            ->addMethods(['getName'])
             ->disableOriginalConstructor()
             ->getMock();
 

--- a/tests/Unit/SearchEndpoint/InnerHitsEndpointTest.php
+++ b/tests/Unit/SearchEndpoint/InnerHitsEndpointTest.php
@@ -54,7 +54,8 @@ class InnerHitsEndpointTest extends \PHPUnit\Framework\TestCase
             ->getMock();
         $innerHit = $this
             ->getMockBuilder('ONGR\ElasticsearchDSL\BuilderInterface')
-            ->setMethods(['getName', 'toArray', 'getType'])
+            ->onlyMethods(['toArray', 'getType'])
+            ->addMethods(['getName'])
             ->getMock();
         $innerHit->expects($this->any())->method('getName')->willReturn('foo');
         $innerHit->expects($this->any())->method('toArray')->willReturn(['foo' => 'bar']);

--- a/tests/Unit/SearchEndpoint/SearchEndpointFactoryTest.php
+++ b/tests/Unit/SearchEndpoint/SearchEndpointFactoryTest.php
@@ -34,8 +34,7 @@ class SearchEndpointFactoryTest extends \PHPUnit\Framework\TestCase
      */
     public function testFactory()
     {
-        $endpoinnt = SearchEndpointFactory::get(AggregationsEndpoint::NAME);
-
-        $this->assertInstanceOf(SearchEndpointInterface::class, $endpoinnt);
+        $endpoint = SearchEndpointFactory::get(AggregationsEndpoint::NAME);
+        $this->assertInstanceOf(SearchEndpointInterface::class, $endpoint);
     }
 }

--- a/tests/Unit/Sort/FieldSortTest.php
+++ b/tests/Unit/Sort/FieldSortTest.php
@@ -19,7 +19,6 @@ class FieldSortTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test for toArray() method.
-     *
      */
     public function testToArray()
     {

--- a/tests/Unit/Sort/NestedSortTest.php
+++ b/tests/Unit/Sort/NestedSortTest.php
@@ -18,7 +18,6 @@ class NestedSortTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test for single nested.
-     *
      */
     public function testSingle()
     {
@@ -37,7 +36,6 @@ class NestedSortTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test for single nested, no filter.
-     *
      */
     public function testNoFilter()
     {
@@ -51,7 +49,6 @@ class NestedSortTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test for single nested.
-     *
      */
     public function testMultipleNesting()
     {

--- a/tests/Unit/Suggest/SuggestTest.php
+++ b/tests/Unit/Suggest/SuggestTest.php
@@ -26,8 +26,6 @@ class SuggestTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Data provider for testToArray()
-     *
-     * @return array[]
      */
     public function getTestToArrayData()
     {


### PR DESCRIPTION
This PR adds PHP 8 compatibility.

It's technically identical to https://github.com/ongr-io/ElasticsearchDSL/pull/348, but does not drop php 7.x.
Instead PHP <7.4 is dropped.
This PR also does not include 7.4 typed properties, as this was the wish of a maintainer to do this seperately.

 - Bumped up PHP to at least 7.4