### PR TITLE
Allow null 'format' in DateRangeAggregation

### DIFF
--- a/src/Aggregation/Bucketing/DateRangeAggregation.php
+++ b/src/Aggregation/Bucketing/DateRangeAggregation.php
@@ -128,17 +128,18 @@ class DateRangeAggregation extends AbstractAggregation
      */
     public function getArray()
     {
-        if ($this->getField() && $this->getFormat() && !empty($this->ranges)) {
+        if ($this->getField() && !empty($this->ranges)) {
             $data = [
-                'format' => $this->getFormat(),
                 'field' => $this->getField(),
                 'ranges' => $this->ranges,
                 'keyed' => $this->keyed,
             ];
-
+            if ($this->getFormat()) {
+                $data['format'] = $this->getFormat();
+            }
             return $data;
         }
-        throw new \LogicException('Date range aggregation must have field, format set and range added.');
+        throw new \LogicException('Date range aggregation must have field and range added.');
     }
 
     /**

--- a/tests/Unit/Aggregation/Bucketing/DateRangeAggregationTest.php
+++ b/tests/Unit/Aggregation/Bucketing/DateRangeAggregationTest.php
@@ -19,7 +19,7 @@ class DateRangeAggregationTest extends \PHPUnit\Framework\TestCase
      * Test if exception is thrown.
      *
      * @expectedException \LogicException
-     * @expectedExceptionMessage Date range aggregation must have field, format set and range added.
+     * @expectedExceptionMessage Date range aggregation must have field and range added.
      */
     public function testIfExceptionIsThrownWhenNoParametersAreSet()
     {


### PR DESCRIPTION
Allow null 'format' in DateRangeAggregation

Without this, calling:
```
        $ranges[] = ['from' => time()-1000, 'to' => time(), 'key' => 'time_range'];
        $rangeAgg = new DateRangeAggregation('myagg', 'created', null, $ranges, true);
```
results in an exception, but it shouldn't as `format` is optional.