### PR TITLE
PHP 8.0 support

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 sudo: false
 language: php
 php:
-  - 7.1
   - 7.2
   - 7.3
   - 7.4snapshot
+  - 8.0
 matrix:
   allow_failures:
       - php: 7.4snapshot

--- a/composer.json
+++ b/composer.json
@@ -11,13 +11,13 @@
         }
     ],
     "require": {
-        "php": "^7.0",
+        "php": "^7.2 || ^8.0",
         "symfony/serializer": "^3.0|^4.0",
         "paragonie/random_compat": "*"
     },
     "require-dev": {
         "elasticsearch/elasticsearch": "^7.0",
-        "phpunit/phpunit": "~6.0",
+        "phpunit/phpunit": "^8.0",
         "squizlabs/php_codesniffer": "^3.0"
     },
     "suggest": {

--- a/tests/Functional/AbstractElasticsearchTestCase.php
+++ b/tests/Functional/AbstractElasticsearchTestCase.php
@@ -31,7 +31,7 @@ abstract class AbstractElasticsearchTestCase extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function setUp()
+    protected function setUp(): void
     {
         parent::setUp();
 
@@ -109,7 +109,7 @@ abstract class AbstractElasticsearchTestCase extends TestCase
     /**
      * {@inheritdoc}
      */
-    protected function tearDown()
+    protected function tearDown(): void
     {
         parent::tearDown();
         $this->deleteIndex();

--- a/tests/Unit/Aggregation/Bucketing/ChildrenAggregationTest.php
+++ b/tests/Unit/Aggregation/Bucketing/ChildrenAggregationTest.php
@@ -20,11 +20,10 @@ class ChildrenAggregationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Tests if ChildrenAggregation#getArray throws exception when expected.
-     *
-     * @expectedException \LogicException
      */
     public function testGetArrayException()
     {
+        $this->expectException(\LogicException::class);
         $aggregation = new ChildrenAggregation('foo');
         $aggregation->getArray();
     }

--- a/tests/Unit/Aggregation/Bucketing/DateHistogramAggregationTest.php
+++ b/tests/Unit/Aggregation/Bucketing/DateHistogramAggregationTest.php
@@ -20,11 +20,10 @@ class DateHistogramAggregationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Tests if ChildrenAggregation#getArray throws exception when expected.
-     *
-     * @expectedException \LogicException
      */
     public function testGetArrayException()
     {
+        $this->expectException(\LogicException::class);
         $aggregation = new DateHistogramAggregation('foo');
         $aggregation->getArray();
     }

--- a/tests/Unit/Aggregation/Bucketing/DateRangeAggregationTest.php
+++ b/tests/Unit/Aggregation/Bucketing/DateRangeAggregationTest.php
@@ -17,24 +17,22 @@ class DateRangeAggregationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test if exception is thrown.
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Date range aggregation must have field, format set and range added.
      */
     public function testIfExceptionIsThrownWhenNoParametersAreSet()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Date range aggregation must have field, format set and range added.');
         $agg = new DateRangeAggregation('test_agg');
         $agg->getArray();
     }
 
     /**
      * Test if exception is thrown when both range parameters are null.
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Either from or to must be set. Both cannot be null.
      */
     public function testIfExceptionIsThrownWhenBothRangesAreNull()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Either from or to must be set. Both cannot be null.');
         $agg = new DateRangeAggregation('test_agg');
         $agg->addRange(null, null);
     }

--- a/tests/Unit/Aggregation/Bucketing/FilterAggregationTest.php
+++ b/tests/Unit/Aggregation/Bucketing/FilterAggregationTest.php
@@ -101,24 +101,22 @@ class FilterAggregationTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test for setField().
-     *
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage doesn't support `field` parameter
      */
     public function testSetField()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage("doesn't support `field` parameter");
         $aggregation = new FilterAggregation('test_agg');
         $aggregation->setField('test_field');
     }
 
     /**
      * Test for toArray() without setting a filter.
-     *
-     * @expectedException        \LogicException
-     * @expectedExceptionMessage has no filter added
      */
     public function testToArrayNoFilter()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('has no filter added');
         $aggregation = new FilterAggregation('test_agg');
         $aggregation->toArray();
     }

--- a/tests/Unit/Aggregation/Bucketing/FiltersAggregationTest.php
+++ b/tests/Unit/Aggregation/Bucketing/FiltersAggregationTest.php
@@ -21,12 +21,11 @@ class FiltersAggregationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test if exception is thrown when not anonymous filter is without name.
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage In not anonymous filters filter name must be set.
      */
     public function testIfExceptionIsThrown()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('In not anonymous filters filter name must be set.');
         $mock = $this->getMockBuilder('ONGR\ElasticsearchDSL\BuilderInterface')->getMock();
         $aggregation = new FiltersAggregation('test_agg');
         $aggregation->addFilter($mock);

--- a/tests/Unit/Aggregation/Bucketing/GeoDistanceAggregationTest.php
+++ b/tests/Unit/Aggregation/Bucketing/GeoDistanceAggregationTest.php
@@ -17,12 +17,11 @@ class GeoDistanceAggregationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test if exception is thrown when field is not set.
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Geo distance aggregation must have a field set.
      */
     public function testGeoDistanceAggregationExceptionWhenFieldIsNotSet()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Geo distance aggregation must have a field set.');
         $agg = new GeoDistanceAggregation('test_agg');
         $agg->setOrigin('50, 70');
         $agg->getArray();
@@ -30,12 +29,11 @@ class GeoDistanceAggregationTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test if exception is thrown when origin is not set.
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Geo distance aggregation must have an origin set.
      */
     public function testGeoDistanceAggregationExceptionWhenOriginIsNotSet()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Geo distance aggregation must have an origin set.');
         $agg = new GeoDistanceAggregation('test_agg');
         $agg->setField('location');
         $agg->getArray();
@@ -43,12 +41,11 @@ class GeoDistanceAggregationTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test if exception is thrown when field is not set.
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Either from or to must be set. Both cannot be null.
      */
     public function testGeoDistanceAggregationAddRangeException()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Either from or to must be set. Both cannot be null.');
         $agg = new GeoDistanceAggregation('test_agg');
         $agg->addRange();
     }

--- a/tests/Unit/Aggregation/Bucketing/GeoHashGridAggregationTest.php
+++ b/tests/Unit/Aggregation/Bucketing/GeoHashGridAggregationTest.php
@@ -20,11 +20,10 @@ class GeoHashGridAggregationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test if exception is thrown.
-     *
-     * @expectedException \LogicException
      */
     public function testGeoHashGridAggregationException()
     {
+        $this->expectException(\LogicException::class);
         $agg = new GeoHashGridAggregation('test_agg');
         $agg->getArray();
     }

--- a/tests/Unit/Aggregation/Bucketing/GlobalAggregationTest.php
+++ b/tests/Unit/Aggregation/Bucketing/GlobalAggregationTest.php
@@ -74,11 +74,10 @@ class GlobalAggregationTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Test for setField method on global aggregation.
-     *
-     * @expectedException \LogicException
      */
     public function testSetField()
     {
+        $this->expectException(\LogicException::class);
         $aggregation = new GlobalAggregation('test_agg');
         $aggregation->setField('test_field');
     }

--- a/tests/Unit/Aggregation/Bucketing/Ipv4RangeAggregationTest.php
+++ b/tests/Unit/Aggregation/Bucketing/Ipv4RangeAggregationTest.php
@@ -17,11 +17,10 @@ class Ipv4RangeAggregationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test exception when field and range are not set.
-     *
-     * @expectedException \LogicException
      */
     public function testIfExceptionIsThrownWhenFieldAndRangeAreNotSet()
     {
+        $this->expectException(\LogicException::class);
         $agg = new Ipv4RangeAggregation('foo');
         $agg->toArray();
     }

--- a/tests/Unit/Aggregation/Bucketing/MissingAggregationTest.php
+++ b/tests/Unit/Aggregation/Bucketing/MissingAggregationTest.php
@@ -17,12 +17,11 @@ class MissingAggregationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test if exception is thrown when field is not set.
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Missing aggregation must have a field set.
      */
     public function testIfExceptionIsThrown()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Missing aggregation must have a field set.');
         $agg = new MissingAggregation('test_agg');
         $agg->getArray();
     }

--- a/tests/Unit/Aggregation/Metric/CardinalityAggregationTest.php
+++ b/tests/Unit/Aggregation/Metric/CardinalityAggregationTest.php
@@ -52,12 +52,11 @@ class CardinalityAggregationTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Tests if CardinalityAggregation#getArray throws exception when expected.
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Cardinality aggregation must have field or script set.
      */
     public function testGetArrayException()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Cardinality aggregation must have field or script set.');
         $aggregation = new CardinalityAggregation('bar');
         $aggregation->getArray();
     }

--- a/tests/Unit/Aggregation/Metric/GeoBoundsAggregationTest.php
+++ b/tests/Unit/Aggregation/Metric/GeoBoundsAggregationTest.php
@@ -20,11 +20,10 @@ class GeoBoundsAggregationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test if exception is thrown.
-     *
-     * @expectedException \LogicException
      */
     public function testGeoBoundsAggregationException()
     {
+        $this->expectException(\LogicException::class);
         $agg = new GeoBoundsAggregation('test_agg');
         $agg->getArray();
     }

--- a/tests/Unit/Aggregation/Metric/GeoCentroidAggregationTest.php
+++ b/tests/Unit/Aggregation/Metric/GeoCentroidAggregationTest.php
@@ -20,11 +20,10 @@ class GeoCentroidAggregationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test if exception is thrown when field is not provided
-     *
-     * @expectedException \LogicException
      */
     public function testGetArrayException()
     {
+        $this->expectException(\LogicException::class);
         $aggregation = new GeoCentroidAggregation('foo');
         $aggregation->getArray();
     }

--- a/tests/Unit/Aggregation/Metric/PercentileRanksAggregationTest.php
+++ b/tests/Unit/Aggregation/Metric/PercentileRanksAggregationTest.php
@@ -26,39 +26,36 @@ class PercentileRanksAggregationTest extends \PHPUnit\Framework\TestCase
     /**
      * Phpunit setup.
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->agg = new PercentileRanksAggregation('foo');
     }
 
     /**
      * Tests if exception is thrown when required parameters not set.
-     *
-     * @expectedException \LogicException
      */
     public function testIfPercentileRanksAggregationThrowsAnException()
     {
+        $this->expectException(\LogicException::class);
         $this->agg->toArray();
     }
 
     /**
      * Tests exception when only field is set.
-     *
-     * @expectedException \LogicException
      */
     public function testIfExceptionIsThrownWhenFieldSetAndValueNotSet()
     {
+        $this->expectException(\LogicException::class);
         $this->agg->setField('bar');
         $this->agg->toArray();
     }
 
     /**
      * Tests exception when only value is set.
-     *
-     * @expectedException \LogicException
      */
     public function testIfExceptionIsThrownWhenScriptSetAndValueNotSet()
     {
+        $this->expectException(\LogicException::class);
         $this->agg->setScript('bar');
         $this->agg->toArray();
     }

--- a/tests/Unit/Aggregation/Metric/PercentilesAggregationTest.php
+++ b/tests/Unit/Aggregation/Metric/PercentilesAggregationTest.php
@@ -17,12 +17,11 @@ class PercentilesAggregationTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Tests if PercentilesAggregation#getArray throws exception when expected.
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage Percentiles aggregation must have field or script set.
      */
     public function testPercentilesAggregationGetArrayException()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('Percentiles aggregation must have field or script set.');
         $aggregation = new PercentilesAggregation('bar');
         $aggregation->getArray();
     }

--- a/tests/Unit/Aggregation/Pipeline/BucketScriptAggregationTest.php
+++ b/tests/Unit/Aggregation/Pipeline/BucketScriptAggregationTest.php
@@ -50,12 +50,11 @@ class BucketScriptAggregationTest extends \PHPUnit\Framework\TestCase
     /**
      * Tests if the exception is thrown in getArray method if no
      * buckets_path or script is set
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage `test` aggregation must have script set.
      */
     public function testGetArrayException()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('`test` aggregation must have script set.');
         $agg = new BucketScriptAggregation('test', []);
 
         $agg->getArray();

--- a/tests/Unit/Aggregation/Pipeline/BucketSelectorAggregationTest.php
+++ b/tests/Unit/Aggregation/Pipeline/BucketSelectorAggregationTest.php
@@ -48,12 +48,11 @@ class BucketSelectorAggregationTest extends \PHPUnit\Framework\TestCase
     /**
      * Tests if the exception is thrown in getArray method if no
      * buckets_path or script is set
-     *
-     * @expectedException \LogicException
-     * @expectedExceptionMessage `test` aggregation must have script set.
      */
     public function testGetArrayException()
     {
+        $this->expectException(\LogicException::class);
+        $this->expectExceptionMessage('`test` aggregation must have script set.');
         $agg = new BucketSelectorAggregation('test', []);
 
         $agg->getArray();

--- a/tests/Unit/ParametersTraitTest.php
+++ b/tests/Unit/ParametersTraitTest.php
@@ -26,7 +26,7 @@ class ParametersTraitTest extends \PHPUnit\Framework\TestCase
     /**
      * {@inheritdoc}
      */
-    public function setUp()
+    protected function setUp(): void
     {
         $this->parametersTraitMock = $this->getMockForTrait('ONGR\ElasticsearchDSL\ParametersTrait');
     }

--- a/tests/Unit/Query/Compound/BoolQueryTest.php
+++ b/tests/Unit/Query/Compound/BoolQueryTest.php
@@ -22,12 +22,11 @@ class BoolQueryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test for addToBool() without setting a correct bool operator.
-     *
-     * @expectedException        \UnexpectedValueException
-     * @expectedExceptionMessage The bool operator acme is not supported
      */
     public function testBoolAddToBoolException()
     {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('The bool operator acme is not supported');
         $bool = new BoolQuery();
         $bool->add(new MatchAllQuery(), 'acme');
     }
@@ -81,12 +80,11 @@ class BoolQueryTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Tests exception thrown if invalid BoolQuery type key is specified
-     *
-     * @expectedException        \UnexpectedValueException
-     * @expectedExceptionMessage The bool operator acme is not supported
      */
     public function testBoolConstructorException()
     {
+        $this->expectException(\UnexpectedValueException::class);
+        $this->expectExceptionMessage('The bool operator acme is not supported');
         new BoolQuery([
             'acme' => [new TermQuery('key1', 'value1')],
         ]);
@@ -190,7 +188,7 @@ class BoolQueryTest extends \PHPUnit\Framework\TestCase
     {
         $bool = new BoolQuery();
 
-        $this->assertInternalType('array', $bool->getQueries());
+        $this->assertIsArray($bool->getQueries());
     }
 
     /**
@@ -215,7 +213,7 @@ class BoolQueryTest extends \PHPUnit\Framework\TestCase
     {
         $bool = new BoolQuery();
 
-        $this->assertInternalType('array', $bool->getQueries(BoolQuery::MUST));
+        $this->assertIsArray($bool->getQueries(BoolQuery::MUST));
     }
 
     /**

--- a/tests/Unit/Query/Geo/GeoBoundingBoxQueryTest.php
+++ b/tests/Unit/Query/Geo/GeoBoundingBoxQueryTest.php
@@ -17,11 +17,10 @@ class GeoBoundingBoxQueryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Test if exception is thrown when geo points are not set.
-     *
-     * @expectedException \LogicException
      */
     public function testGeoBoundBoxQueryException()
     {
+        $this->expectException(\LogicException::class);
         $query = new GeoBoundingBoxQuery('location', []);
         $query->toArray();
     }

--- a/tests/Unit/Query/Span/SpanOrQueryTest.php
+++ b/tests/Unit/Query/Span/SpanOrQueryTest.php
@@ -43,7 +43,7 @@ class SpanOrQueryTest extends \PHPUnit\Framework\TestCase
         $this->assertEquals($result, $query->toArray());
 
         $result = $query->getQueries();
-        $this->assertInternalType('array', $result);
+        $this->assertIsArray($result);
         $this->assertEquals(1, count($result));
     }
 }

--- a/tests/Unit/Query/Specialized/TemplateQueryTest.php
+++ b/tests/Unit/Query/Specialized/TemplateQueryTest.php
@@ -56,11 +56,10 @@ class TemplateQueryTest extends \PHPUnit\Framework\TestCase
 
     /**
      * Tests toArray() exception
-     *
-     * @expectedException \InvalidArgumentException
      */
     public function testToArrayException()
     {
+        $this->expectException(\InvalidArgumentException::class);
         $query = new TemplateQuery();
         $query->toArray();
     }

--- a/tests/Unit/SearchEndpoint/SearchEndpointFactoryTest.php
+++ b/tests/Unit/SearchEndpoint/SearchEndpointFactoryTest.php
@@ -21,11 +21,10 @@ class SearchEndpointFactoryTest extends \PHPUnit\Framework\TestCase
 {
     /**
      * Tests get method exception.
-     *
-     * @expectedException \RuntimeException
      */
     public function testGet()
     {
+        $this->expectException(\RuntimeException::class);
         SearchEndpointFactory::get('foo');
     }
 


### PR DESCRIPTION
Adds PHP 8.0 support, but bumps minimum PHP version to 7.2, because PHPUnit 8 requires at least PHP 7.2.